### PR TITLE
Use default value of RCVHWM for zmq sockets

### DIFF
--- a/savant/utils/zeromq.py
+++ b/savant/utils/zeromq.py
@@ -98,7 +98,6 @@ class ZeroMQSource:
         self.receive_timeout = receive_timeout
         self.zmq_context = zmq.Context()
         self.receiver = self.zmq_context.socket(self.socket_type.value)
-        self.receiver.setsockopt(zmq.RCVHWM, 1)
         if bind:
             self.receiver.bind(socket)
         else:


### PR DESCRIPTION
The default value is [1000](http://api.zeromq.org/4-0:zmq-setsockopt#:~:text=all-,ZMQ_RCVHWM,-%3A%20Set%20high%20water)