### PR TITLE
Change DEALER/ROUTER to PUB/SUB

### DIFF
--- a/samples/nvidia_car_classification/docker-compose.l4t.yml
+++ b/samples/nvidia_car_classification/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
     command: samples/nvidia_car_classification/module.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/nvidia-sample
       - SOURCE_ID=nvidia-sample-processed

--- a/samples/nvidia_car_classification/docker-compose.x86.yml
+++ b/samples/nvidia_car_classification/docker-compose.x86.yml
@@ -32,7 +32,7 @@ services:
     command: samples/nvidia_car_classification/module.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/nvidia-sample
       - SOURCE_ID=nvidia-sample-processed

--- a/samples/opencv_cuda_bg_remover_mog2/docker-compose.l4t.yml
+++ b/samples/opencv_cuda_bg_remover_mog2/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
     command: samples/opencv_cuda_bg_remover_mog2/demo.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/road-traffic
       - SOURCE_ID=road-traffic-processed

--- a/samples/opencv_cuda_bg_remover_mog2/docker-compose.x86.yml
+++ b/samples/opencv_cuda_bg_remover_mog2/docker-compose.x86.yml
@@ -32,7 +32,7 @@ services:
     command: samples/opencv_cuda_bg_remover_mog2/demo.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/road-traffic
       - SOURCE_ID=road-traffic-processed

--- a/samples/peoplenet_detector/docker-compose.l4t.yml
+++ b/samples/peoplenet_detector/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
     command: samples/peoplenet_detector/demo.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/city-traffic
       - SOURCE_ID=city-traffic-processed

--- a/samples/peoplenet_detector/docker-compose.x86.yml
+++ b/samples/peoplenet_detector/docker-compose.x86.yml
@@ -32,7 +32,7 @@ services:
     command: samples/peoplenet_detector/demo.yml
     environment:
       - ZMQ_SRC_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_SRC_TYPE=ROUTER
+      - ZMQ_SRC_TYPE=SUB
       - ZMQ_SRC_BIND=True
       - ZMQ_SINK_ENDPOINT=ipc:///tmp/zmq-sockets/output-video.ipc
       - ZMQ_SINK_TYPE=PUB
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
     environment:
       - ZMQ_ENDPOINT=ipc:///tmp/zmq-sockets/input-video.ipc
-      - ZMQ_TYPE=DEALER
+      - ZMQ_TYPE=PUB
       - ZMQ_BIND=False
       - RTSP_URI=rtsp://rtsp-server:8554/city-traffic
       - SOURCE_ID=city-traffic-processed


### PR DESCRIPTION
It is necessary to do this because we mostly use RTSP or other real-time sources in our compose manifests for demonstrations. When we used DEALER/ROUTER it caused the situation of RT-sources being stuck while the module was launching which is not the right approach for handling RT-sources. The PUB/SUB pair ideally fits the situation when RT-sources are deployed.

Closes #169 