### PR TITLE
155: RTSP Source crashes when 'dealer' (and 'req'?) scheme is used while the 'router/rep' is not available for a long period

### DIFF
--- a/adapters/gst/sources/rtsp.sh
+++ b/adapters/gst/sources/rtsp.sh
@@ -29,6 +29,7 @@ elif [[ -n "${FPS_PERIOD_FRAMES}" ]]; then
 else
     FPS_PERIOD="period-frames=1000"
 fi
+BUFFER_MAX_BYTES="${BUFFER_MAX_BYTES:="10485760"}"
 
 handler() {
     kill -s SIGINT "${child_pid}"
@@ -47,6 +48,7 @@ if [[ "${CALCULATE_DTS,,}" == "true" ]]; then
     PIPELINE+=(calculate_dts !)
 fi
 PIPELINE+=(
+    queue leaky=downstream max-size-bytes="${BUFFER_MAX_BYTES}" max-size-buffers=0 max-size-time=0 !
     video_to_avro_serializer source-id="${SOURCE_ID}" !
     zeromq_sink socket="${ZMQ_ENDPOINT}" socket-type="${ZMQ_SOCKET_TYPE}" bind="${ZMQ_SOCKET_BIND}"
     sync="${SYNC_OUTPUT}" ts-offset="${SYNC_DELAY}" source-id="${SOURCE_ID}"

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -328,6 +328,7 @@ The adapter parameters are set with environment variables:
 - `SYNC_OUTPUT` - flag indicates the need to send frames from source synchronously (i.e. at the source file rate); default is `False`;
 - `SYNC_DELAY` - delay in seconds before sending frames; useful when the source has B-frames to avoid sending frames in batches; default is `0`;
 - `CALCULATE_DTS` - flag indicates whether the adapter should calculate DTS for frames; set this flag when the source has B-frames; default is `False`;
+- `BUFFER_MAX_BYTES` - maximum amount of data in the buffer; default is `10485760` (10 MB);
 - `FPS_PERIOD_FRAMES` - number of frames between FPS reports; default is `1000`;
 - `FPS_PERIOD_SECONDS` - number of seconds between FPS reports; default is `None`;
 - `FPS_OUTPUT` - path to the file where the FPS reports will be written; default is `stdout`.

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -366,6 +366,12 @@ def pictures_source(
     help='Calculate DTS for frames. Set this flag when the source has B-frames.',
     show_default=True,
 )
+@click.option(
+    '--buffer-max-bytes',
+    default=10485760,
+    help='Maximum amount of data in the buffer.',
+    show_default=True,
+)
 @adapter_docker_image_option('gstreamer')
 @click.argument('rtsp_uri', required=True)
 def rtsp_source(
@@ -376,6 +382,7 @@ def rtsp_source(
     sync: bool,
     sync_delay: Optional[int],
     calculate_dts: bool,
+    buffer_max_bytes: int,
     docker_image: str,
     fps_period_frames: Optional[int],
     fps_period_seconds: Optional[float],
@@ -392,6 +399,7 @@ def rtsp_source(
     ) + [
         f'RTSP_URI={rtsp_uri}',
         f'CALCULATE_DTS={calculate_dts}',
+        f'BUFFER_MAX_BYTES={buffer_max_bytes}',
     ]
     if sync and sync_delay is not None:
         envs.append(f'SYNC_DELAY={sync_delay}')


### PR DESCRIPTION
Closes #155 