### PR TITLE
Refactor python imports (#353)

### DIFF
--- a/adapters/ds/gst_plugins/python/always_on_rtsp_frame_processor.py
+++ b/adapters/ds/gst_plugins/python/always_on_rtsp_frame_processor.py
@@ -8,7 +8,7 @@ import cv2
 from adapters.ds.sinks.always_on_rtsp.last_frame import LastFrame
 from adapters.ds.sinks.always_on_rtsp.timestamp_overlay import TimestampOverlay
 from savant.deepstream.opencv_utils import nvds_to_gpu_mat
-from savant.gstreamer import Gst, GstBase, GObject
+from savant.gstreamer import GObject, Gst, GstBase
 from savant.gstreamer.utils import propagate_gst_setting_error
 from savant.utils.logging import LoggerMixin
 

--- a/adapters/ds/gst_plugins/python/always_on_rtsp_frame_sink.py
+++ b/adapters/ds/gst_plugins/python/always_on_rtsp_frame_sink.py
@@ -5,7 +5,7 @@ from typing import Any
 from adapters.ds.sinks.always_on_rtsp.last_frame import LastFrame
 from adapters.ds.sinks.always_on_rtsp.timestamp_overlay import TimestampOverlay
 from savant.deepstream.opencv_utils import nvds_to_gpu_mat
-from savant.gstreamer import Gst, GstBase, GObject
+from savant.gstreamer import GObject, Gst, GstBase
 from savant.gstreamer.utils import propagate_gst_setting_error
 from savant.utils.logging import LoggerMixin
 

--- a/adapters/ds/gst_plugins/python/savant_rs_video_player.py
+++ b/adapters/ds/gst_plugins/python/savant_rs_video_player.py
@@ -1,7 +1,6 @@
+from dataclasses import dataclass
 from threading import Event
 from typing import Dict, Optional
-
-from dataclasses import dataclass
 
 from savant.gstreamer import GLib, GObject, Gst
 from savant.gstreamer.utils import on_pad_event, pad_to_source_id

--- a/adapters/ds/sinks/always_on_rtsp/__main__.py
+++ b/adapters/ds/sinks/always_on_rtsp/__main__.py
@@ -20,9 +20,9 @@ from savant.gstreamer.codecs import CODEC_BY_CAPS_NAME, Codec
 from savant.gstreamer.element_factory import GstElementFactory
 from savant.gstreamer.metadata import metadata_pop_frame_meta
 from savant.gstreamer.runner import GstPipelineRunner
+from savant.utils.logging import get_logger
 from savant.utils.platform import is_aarch64
 from savant.utils.zeromq import ReceiverSocketTypes
-from savant.utils.logging import get_logger
 
 LOGGER_NAME = 'ao_sink'
 logger = get_logger(LOGGER_NAME)

--- a/adapters/gst/gst_plugins/python/ffmpeg_src.py
+++ b/adapters/gst/gst_plugins/python/ffmpeg_src.py
@@ -2,15 +2,13 @@
 import inspect
 from typing import Dict, NamedTuple, Optional
 
-from ffmpeg_input import FFMpegSource, FFmpegLogLevel, VideoFrameEnvelope
+from ffmpeg_input import FFmpegLogLevel, FFMpegSource, VideoFrameEnvelope
 
 from savant.gstreamer import GObject, Gst, GstBase
 from savant.gstreamer.codecs import Codec
-from savant.gstreamer.utils import (
-    propagate_gst_error,
-    propagate_gst_setting_error,
-    required_property,
-)
+from savant.gstreamer.utils import (propagate_gst_error,
+                                    propagate_gst_setting_error,
+                                    required_property)
 from savant.utils.logging import LoggerMixin
 
 DEFAULT_QUEUE_LEN = 100

--- a/adapters/gst/gst_plugins/python/fps_meter.py
+++ b/adapters/gst/gst_plugins/python/fps_meter.py
@@ -2,8 +2,8 @@ from enum import Enum
 from typing import Any, Optional
 
 from savant.gstreamer import GObject, Gst, GstBase
-from savant.utils.logging import LoggerMixin
 from savant.utils.fps_meter import FPSMeter
+from savant.utils.logging import LoggerMixin
 
 
 class Output(Enum):

--- a/adapters/gst/gst_plugins/python/media_files_src_bin.py
+++ b/adapters/gst/gst_plugins/python/media_files_src_bin.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
 from savant.gstreamer import GLib, GObject, Gst
-from savant.gstreamer.codecs import Codec, CODEC_BY_CAPS_NAME
+from savant.gstreamer.codecs import CODEC_BY_CAPS_NAME, Codec
 from savant.gstreamer.metadata import DEFAULT_FRAMERATE
 from savant.gstreamer.utils import on_pad_event
 from savant.utils.file_types import FileType, parse_mime_types

--- a/adapters/gst/gst_plugins/python/savant_rs_serializer.py
+++ b/adapters/gst/gst_plugins/python/savant_rs_serializer.py
@@ -1,12 +1,11 @@
 import json
 from fractions import Fraction
 from pathlib import Path
-from typing import Any, NamedTuple, Optional, Tuple, Union
-from typing import Any, Dict, NamedTuple, Optional, Union
-from splitstream import splitfile
+from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
 
 from savant_rs.primitives import EndOfStream, VideoFrame
 from savant_rs.utils.serialization import Message, save_message_to_bytes
+from splitstream import splitfile
 
 from savant.api.builder import build_video_frame
 from savant.api.enums import ExternalFrameType

--- a/adapters/gst/gst_plugins/python/video_files_sink.py
+++ b/adapters/gst/gst_plugins/python/video_files_sink.py
@@ -3,7 +3,8 @@ from typing import Dict, Optional, Union
 
 from savant_rs.primitives import EndOfStream, VideoFrame
 
-from adapters.python.sinks.chunk_writer import ChunkWriter, CompositeChunkWriter
+from adapters.python.sinks.chunk_writer import (ChunkWriter,
+                                                CompositeChunkWriter)
 from adapters.python.sinks.metadata_json import MetadataJsonWriter, Patterns
 from gst_plugins.python.savant_rs_video_demux import FrameParams, build_caps
 from savant.api.enums import ExternalFrameType

--- a/adapters/gst/gst_plugins/python/zeromq_sink.py
+++ b/adapters/gst/gst_plugins/python/zeromq_sink.py
@@ -4,21 +4,15 @@ from typing import List, Union
 
 import zmq
 
-from gst_plugins.python.zeromq_properties import (
-    socket_type_property,
-    ZEROMQ_PROPERTIES,
-)
+from gst_plugins.python.zeromq_properties import (ZEROMQ_PROPERTIES,
+                                                  socket_type_property)
 from savant.gstreamer import GObject, Gst, GstBase
-from savant.gstreamer.utils import propagate_gst_error, propagate_gst_setting_error
+from savant.gstreamer.utils import (propagate_gst_error,
+                                    propagate_gst_setting_error)
 from savant.utils.logging import LoggerMixin
-from savant.utils.zeromq import (
-    Defaults,
-    END_OF_STREAM_MESSAGE,
-    SenderSocketTypes,
-    ZMQException,
-    parse_zmq_socket_uri,
-    receive_response,
-)
+from savant.utils.zeromq import (END_OF_STREAM_MESSAGE, Defaults,
+                                 SenderSocketTypes, ZMQException,
+                                 parse_zmq_socket_uri, receive_response)
 
 
 class ZeroMQSink(LoggerMixin, GstBase.BaseSink):

--- a/adapters/python/sinks/image_files.py
+++ b/adapters/python/sinks/image_files.py
@@ -8,12 +8,10 @@ from typing import Dict, List
 from savant_rs.primitives import EndOfStream, VideoFrame
 from savant_rs.utils.serialization import Message, load_message_from_bytes
 
-from adapters.python.sinks.chunk_writer import ChunkWriter, CompositeChunkWriter
-from adapters.python.sinks.metadata_json import (
-    MetadataJsonWriter,
-    Patterns,
-    frame_has_objects,
-)
+from adapters.python.sinks.chunk_writer import (ChunkWriter,
+                                                CompositeChunkWriter)
+from adapters.python.sinks.metadata_json import (MetadataJsonWriter, Patterns,
+                                                 frame_has_objects)
 from savant.api.enums import ExternalFrameType
 from savant.utils.logging import get_logger
 from savant.utils.zeromq import ZeroMQSource, build_topic_prefix

--- a/adapters/python/sinks/metadata_json.py
+++ b/adapters/python/sinks/metadata_json.py
@@ -6,13 +6,8 @@ import traceback
 from distutils.util import strtobool
 from typing import Any, Dict, Optional
 
-from savant_rs.primitives import (
-    Attribute,
-    AttributeValue,
-    AttributeValueType,
-    EndOfStream,
-    VideoFrame,
-)
+from savant_rs.primitives import (Attribute, AttributeValue,
+                                  AttributeValueType, EndOfStream, VideoFrame)
 from savant_rs.utils.serialization import Message, load_message_from_bytes
 from savant_rs.video_object_query import MatchQuery
 

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -7,17 +7,14 @@ import statistics
 import sys
 import time
 from dataclasses import dataclass
-from typing import List, Dict, Callable, Tuple, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from savant.deepstream.opencv_utils import (
-    nvds_to_gpu_mat,
-    alpha_comp,
-    draw_rect,
-    apply_cuda_filter,
-)
-from savant.deepstream.utils import nvds_frame_meta_iterator, get_nvds_buf_surface
+from savant.deepstream.opencv_utils import (alpha_comp, apply_cuda_filter,
+                                            draw_rect, nvds_to_gpu_mat)
+from savant.deepstream.utils import (get_nvds_buf_surface,
+                                     nvds_frame_meta_iterator)
 
 sys.path.append('../../')
 
@@ -25,8 +22,8 @@ import cv2
 import gi
 
 gi.require_version('Gst', '1.0')
-from gi.repository import GLib, Gst
 import pyds
+from gi.repository import GLib, Gst
 
 scale = 10**6  # milliseconds
 RECT_COLOR = (127, 127, 127, 255)  # gray

--- a/gst_plugins/python/frame_tag_filter.py
+++ b/gst_plugins/python/frame_tag_filter.py
@@ -3,21 +3,16 @@ from itertools import count
 from typing import List, Optional
 
 import pyds
-from pygstsavantframemeta import (
-    gst_buffer_add_savant_frame_meta,
-    nvds_frame_meta_get_nvds_savant_frame_meta,
-)
+from pygstsavantframemeta import (gst_buffer_add_savant_frame_meta,
+                                  nvds_frame_meta_get_nvds_savant_frame_meta)
 
 from gst_plugins.python.frame_tag_filter_common import build_stream_part_event
 from savant.deepstream.utils import nvds_frame_meta_iterator
 from savant.gstreamer import GObject, Gst
 from savant.gstreamer.metadata import get_source_frame_meta
-from savant.gstreamer.utils import (
-    RequiredPropertyError,
-    on_pad_event,
-    propagate_gst_setting_error,
-    required_property,
-)
+from savant.gstreamer.utils import (RequiredPropertyError, on_pad_event,
+                                    propagate_gst_setting_error,
+                                    required_property)
 from savant.utils.logging import LoggerMixin
 
 SINK_PAD_TEMPLATE = Gst.PadTemplate.new(

--- a/gst_plugins/python/pyfunc.py
+++ b/gst_plugins/python/pyfunc.py
@@ -3,10 +3,11 @@
 Can be used for metadata conversion, inference post-processing, and
 other tasks.
 """
-from typing import Any, Optional
 import json
-from savant.base.pyfunc import PyFunc, BasePyFuncPlugin
-from savant.gstreamer import GLib, Gst, GstBase, GObject  # noqa: F401
+from typing import Any, Optional
+
+from savant.base.pyfunc import BasePyFuncPlugin, PyFunc
+from savant.gstreamer import GLib, GObject, Gst, GstBase  # noqa: F401
 from savant.utils.logging import LoggerMixin
 
 # RGBA format is required to access the frame (pyds.get_nvds_buf_surface)

--- a/gst_plugins/python/savant_rs_video_decode_bin.py
+++ b/gst_plugins/python/savant_rs_video_decode_bin.py
@@ -1,17 +1,16 @@
 """SavantRsVideoDecodeBin element."""
 import time
-
+from dataclasses import dataclass
 from threading import Event, Lock
 from typing import Dict, Optional
 
-from dataclasses import dataclass
-
+from gst_plugins.python.savant_rs_video_demux import \
+    SAVANT_RS_VIDEO_DEMUX_PROPERTIES
 from savant.gstreamer import GLib, GObject, Gst  # noqa:F401
-from savant.gstreamer.codecs import Codec, CODEC_BY_CAPS_NAME
+from savant.gstreamer.codecs import CODEC_BY_CAPS_NAME, Codec
 from savant.gstreamer.utils import on_pad_event, pad_to_source_id
 from savant.utils.logging import LoggerMixin
 from savant.utils.platform import is_aarch64
-from gst_plugins.python.savant_rs_video_demux import SAVANT_RS_VIDEO_DEMUX_PROPERTIES
 
 OUT_CAPS = Gst.Caps.from_string('video/x-raw(memory:NVMM);video/x-raw')
 DEFAULT_PASS_EOS = True

--- a/gst_plugins/python/savant_rs_video_demux.py
+++ b/gst_plugins/python/savant_rs_video_demux.py
@@ -13,13 +13,11 @@ from savant.api.enums import ExternalFrameType
 from savant.api.parser import convert_ts, parse_tags, parse_video_objects
 from savant.gstreamer import GObject, Gst
 from savant.gstreamer.codecs import CODEC_BY_NAME, Codec
-from savant.gstreamer.metadata import (
-    DEFAULT_FRAMERATE,
-    OnlyExtendedDict,
-    SourceFrameMeta,
-    metadata_add_frame_meta,
-)
-from savant.gstreamer.utils import load_message_from_gst_buffer, propagate_gst_error
+from savant.gstreamer.metadata import (DEFAULT_FRAMERATE, OnlyExtendedDict,
+                                       SourceFrameMeta,
+                                       metadata_add_frame_meta)
+from savant.gstreamer.utils import (load_message_from_gst_buffer,
+                                    propagate_gst_error)
 from savant.utils.logging import LoggerMixin
 
 DEFAULT_SOURCE_TIMEOUT = 60

--- a/gst_plugins/python/zeromq_source_bin.py
+++ b/gst_plugins/python/zeromq_source_bin.py
@@ -1,11 +1,10 @@
 """ZeroMQ src bin."""
-from savant.gstreamer import GObject, Gst
-from savant.utils.logging import LoggerMixin
 from gst_plugins.python.savant_rs_video_decode_bin import (
     SAVANT_RS_VIDEO_DECODE_BIN_PROPERTIES,
-    SAVANT_RS_VIDEO_DECODE_BIN_SRC_PAD_TEMPLATE,
-)
+    SAVANT_RS_VIDEO_DECODE_BIN_SRC_PAD_TEMPLATE)
 from gst_plugins.python.zeromq_src import ZEROMQ_SRC_PROPERTIES
+from savant.gstreamer import GObject, Gst
+from savant.utils.logging import LoggerMixin
 
 
 class ZeroMQSourceBin(LoggerMixin, Gst.Bin):

--- a/gst_plugins/python/zeromq_src.py
+++ b/gst_plugins/python/zeromq_src.py
@@ -4,24 +4,14 @@ from typing import Optional
 
 import zmq
 
+from gst_plugins.python.zeromq_properties import (ZEROMQ_PROPERTIES,
+                                                  socket_type_property)
 from savant.gstreamer import GObject, Gst, GstBase
-from savant.gstreamer.utils import (
-    gst_buffer_from_list,
-    propagate_gst_error,
-    propagate_gst_setting_error,
-)
+from savant.gstreamer.utils import (gst_buffer_from_list, propagate_gst_error,
+                                    propagate_gst_setting_error)
 from savant.utils.logging import LoggerMixin
-from savant.utils.zeromq import (
-    Defaults,
-    ReceiverSocketTypes,
-    ZeroMQSource,
-    ZMQException,
-    build_topic_prefix,
-)
-from gst_plugins.python.zeromq_properties import (
-    socket_type_property,
-    ZEROMQ_PROPERTIES,
-)
+from savant.utils.zeromq import (Defaults, ReceiverSocketTypes, ZeroMQSource,
+                                 ZMQException, build_topic_prefix)
 
 ZEROMQ_SRC_PROPERTIES = {
     **ZEROMQ_PROPERTIES,

--- a/libs/savantboost/pysavantboost/__init__.py
+++ b/libs/savantboost/pysavantboost/__init__.py
@@ -1,15 +1,7 @@
-from .pysavantboost import (
-    nms,
-    ostream_redirect,
-    cut_rotated_bbox,
-    NvRBboxCoords,
-    add_rbbox_to_object_meta,
-    iter_over_rbbox,
-    ObjectsPreprocessing,
-    Image,
-    get_rbbox,
-    PyDSCudaMemory,
-)
+from .pysavantboost import (Image, NvRBboxCoords, ObjectsPreprocessing,
+                            PyDSCudaMemory, add_rbbox_to_object_meta,
+                            cut_rotated_bbox, get_rbbox, iter_over_rbbox, nms,
+                            ostream_redirect)
 
 __all__ = (
     'nms',

--- a/libs/savantboost/pysavantboost/custom_preprocessing.py
+++ b/libs/savantboost/pysavantboost/custom_preprocessing.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+
 from pysavantboost import Image
 
 

--- a/samples/age_gender_recognition/age_gender_converter.py
+++ b/samples/age_gender_recognition/age_gender_converter.py
@@ -1,6 +1,8 @@
 """Age gender converter module."""
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Optional, Tuple
+
 import numpy as np
+
 from savant.base.converter import BaseAttributeModelOutputConverter
 from savant.base.model import AttributeModel
 from savant.parameter_storage import param_storage

--- a/samples/age_gender_recognition/age_gender_preproc.py
+++ b/samples/age_gender_recognition/age_gender_preproc.py
@@ -1,13 +1,12 @@
 """Module custom model input preprocessing."""
 
+import cv2
+import numpy as np
+
 from savant.base.input_preproc import BasePreprocessObjectImage
 from savant.meta.object import ObjectMeta
-
-import cv2
-
 from savant.parameter_storage import param_storage
 from savant.utils.image import GPUImage
-import numpy as np
 
 REFERENCE_FACIAL_POINTS = np.array(
     [

--- a/samples/age_gender_recognition/overlay.py
+++ b/samples/age_gender_recognition/overlay.py
@@ -1,5 +1,5 @@
 """Overlay dashboard module."""
-from savant_rs.draw_spec import ObjectDraw, LabelDraw
+from savant_rs.draw_spec import LabelDraw, ObjectDraw
 
 from savant.deepstream.drawfunc import NvDsDrawFunc
 from savant.meta.object import ObjectMeta

--- a/samples/age_gender_recognition/selector.py
+++ b/samples/age_gender_recognition/selector.py
@@ -1,6 +1,7 @@
 """Detector's bbox selectors."""
-from numba import njit, uint16, float32
 import numpy as np
+from numba import float32, njit, uint16
+
 from savant.base.selector import BaseSelector
 
 

--- a/samples/age_gender_recognition/smoothing.py
+++ b/samples/age_gender_recognition/smoothing.py
@@ -2,9 +2,9 @@
 from typing import Dict, Tuple
 
 from samples.age_gender_recognition.smoothed_counter import SmoothedCounter
-from savant.gstreamer import Gst
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
+from savant.gstreamer import Gst
 from savant.parameter_storage import param_storage
 
 MODEL_NAME = param_storage()['detection_model_name']

--- a/samples/conditional_video_processing/conditional_video_processing.py
+++ b/samples/conditional_video_processing/conditional_video_processing.py
@@ -5,7 +5,8 @@ from pygstsavantframemeta import nvds_frame_meta_get_nvds_savant_frame_meta
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
 from savant.gstreamer import Gst
-from savant.gstreamer.metadata import get_source_frame_meta, metadata_add_frame_meta
+from savant.gstreamer.metadata import (get_source_frame_meta,
+                                       metadata_add_frame_meta)
 
 
 class ConditionalVideoProcessing(NvDsPyFuncPlugin):

--- a/samples/nvidia_car_classification/overlay.py
+++ b/samples/nvidia_car_classification/overlay.py
@@ -1,8 +1,6 @@
 """Draw func adds car classification models outputs: car color, car make, car type."""
-from savant_rs.draw_spec import (
-    LabelDraw,
-    ObjectDraw,
-)
+from savant_rs.draw_spec import LabelDraw, ObjectDraw
+
 from savant.deepstream.drawfunc import NvDsDrawFunc
 from savant.meta.object import ObjectMeta
 

--- a/samples/opencv_cuda_bg_remover_mog2/bgremover.py
+++ b/samples/opencv_cuda_bg_remover_mog2/bgremover.py
@@ -1,12 +1,11 @@
 """Background remover module."""
-from savant.gstreamer import Gst
-from savant.deepstream.meta.frame import NvDsFrameMeta
-from savant.deepstream.pyfunc import NvDsPyFuncPlugin
-from savant.utils.artist import Artist
-from savant.deepstream.opencv_utils import (
-    nvds_to_gpu_mat,
-)
 import cv2
+
+from savant.deepstream.meta.frame import NvDsFrameMeta
+from savant.deepstream.opencv_utils import nvds_to_gpu_mat
+from savant.deepstream.pyfunc import NvDsPyFuncPlugin
+from savant.gstreamer import Gst
+from savant.utils.artist import Artist
 
 
 class BgRemover(NvDsPyFuncPlugin):

--- a/samples/peoplenet_detector/analytics.py
+++ b/samples/peoplenet_detector/analytics.py
@@ -1,11 +1,13 @@
 """Analytics module."""
 from collections import defaultdict
+
 import numpy as np
-from savant.gstreamer import Gst
+
+from samples.peoplenet_detector.person_face_matching import match_person_faces
+from samples.peoplenet_detector.smoothed_counter import SmoothedCounter
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
-from samples.peoplenet_detector.smoothed_counter import SmoothedCounter
-from samples.peoplenet_detector.person_face_matching import match_person_faces
+from savant.gstreamer import Gst
 
 
 class Analytics(NvDsPyFuncPlugin):

--- a/samples/peoplenet_detector/animation.py
+++ b/samples/peoplenet_detector/animation.py
@@ -1,6 +1,8 @@
 """Animation module."""
 from pathlib import Path
+
 import cv2
+
 from samples.peoplenet_detector.utils import load_sprite
 
 

--- a/samples/peoplenet_detector/overlay.py
+++ b/samples/peoplenet_detector/overlay.py
@@ -1,12 +1,13 @@
 """Overlay dashboard module."""
 from pathlib import Path
+
 import cv2
 
-from savant.deepstream.drawfunc import NvDsDrawFunc
-from savant.deepstream.meta.frame import NvDsFrameMeta, BBox
-from savant.utils.artist import Position, Artist
 from samples.peoplenet_detector.animation import Animation
-from samples.peoplenet_detector.utils import load_sprite, get_font_scale
+from samples.peoplenet_detector.utils import get_font_scale, load_sprite
+from savant.deepstream.drawfunc import NvDsDrawFunc
+from savant.deepstream.meta.frame import BBox, NvDsFrameMeta
+from savant.utils.artist import Artist, Position
 
 
 class Overlay(NvDsDrawFunc):

--- a/samples/peoplenet_detector/person_face_matching.py
+++ b/samples/peoplenet_detector/person_face_matching.py
@@ -1,5 +1,6 @@
 """Person-face matching module."""
 from typing import List
+
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 

--- a/samples/peoplenet_detector/utils.py
+++ b/samples/peoplenet_detector/utils.py
@@ -1,7 +1,8 @@
 """Utilies module."""
 from typing import Tuple
-import numpy as np
+
 import cv2
+import numpy as np
 
 
 def load_sprite(path: str, target_height: int) -> cv2.cuda.GpuMat:

--- a/samples/source_adapter_with_json_metadata/convert_coco_to_savant.py
+++ b/samples/source_adapter_with_json_metadata/convert_coco_to_savant.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+
 import click
 from pycocotools.coco import COCO
 

--- a/samples/source_adapter_with_json_metadata/metric.py
+++ b/samples/source_adapter_with_json_metadata/metric.py
@@ -1,7 +1,7 @@
 """Analytics module."""
-from savant.gstreamer import Gst
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
+from savant.gstreamer import Gst
 
 
 class IOU(NvDsPyFuncPlugin):

--- a/samples/template/module/custom_pyfunc.py
+++ b/samples/template/module/custom_pyfunc.py
@@ -1,7 +1,7 @@
 """Custom PyFunc implementation."""
-from savant.gstreamer import Gst
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
+from savant.gstreamer import Gst
 
 
 class CustomPyFunc(NvDsPyFuncPlugin):

--- a/samples/template/module/run.py
+++ b/samples/template/module/run.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from savant.entrypoint.main import main
 
-
 if __name__ == '__main__':
     main('module.yml')
     print('done')

--- a/samples/traffic_meter/line_crossing.py
+++ b/samples/traffic_meter/line_crossing.py
@@ -1,12 +1,15 @@
-from collections import defaultdict
 import sys
+from collections import defaultdict
+
 import yaml
+from savant_rs.primitives.geometry import Point, PolygonalArea
 from statsd import StatsClient
-from savant_rs.primitives.geometry import PolygonalArea, Point
-from savant.gstreamer import Gst
+
+from samples.traffic_meter.utils import (Direction, Point,
+                                         TwoLinesCrossingTracker)
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.deepstream.pyfunc import NvDsPyFuncPlugin
-from samples.traffic_meter.utils import Point, Direction, TwoLinesCrossingTracker
+from savant.gstreamer import Gst
 
 
 class ConditionalDetectorSkip(NvDsPyFuncPlugin):

--- a/samples/traffic_meter/overlay.py
+++ b/samples/traffic_meter/overlay.py
@@ -1,10 +1,12 @@
-from itertools import chain
 from collections import defaultdict
+from itertools import chain
+
 import cv2
-from savant.deepstream.drawfunc import NvDsDrawFunc
-from savant.deepstream.meta.frame import NvDsFrameMeta, BBox
-from savant.utils.artist import Position, Artist
+
 from samples.traffic_meter.utils import Direction, RandColorIterator
+from savant.deepstream.drawfunc import NvDsDrawFunc
+from savant.deepstream.meta.frame import BBox, NvDsFrameMeta
+from savant.utils.artist import Artist, Position
 
 
 class Overlay(NvDsDrawFunc):

--- a/samples/traffic_meter/utils.py
+++ b/samples/traffic_meter/utils.py
@@ -1,15 +1,12 @@
 """Line crossing trackers."""
-from collections import deque, defaultdict
-from enum import Enum
-from typing import Optional, Sequence, List, Tuple
-import random
 import math
-from savant_rs.primitives.geometry import (
-    PolygonalArea,
-    Segment,
-    IntersectionKind,
-    Point,
-)
+import random
+from collections import defaultdict, deque
+from enum import Enum
+from typing import List, Optional, Sequence, Tuple
+
+from savant_rs.primitives.geometry import (IntersectionKind, Point,
+                                           PolygonalArea, Segment)
 
 
 class Direction(Enum):

--- a/savant/__init__.py
+++ b/savant/__init__.py
@@ -1,4 +1,3 @@
 from savant.utils.version import version
 
-
 __version__ = version.SAVANT

--- a/savant/api/builder.py
+++ b/savant/api/builder.py
@@ -1,13 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from savant_rs.primitives import (
-    Attribute,
-    AttributeValue,
-    IdCollisionResolutionPolicy,
-    VideoFrame,
-    VideoFrameContent,
-    VideoObject,
-)
+from savant_rs.primitives import (Attribute, AttributeValue,
+                                  IdCollisionResolutionPolicy, VideoFrame,
+                                  VideoFrameContent, VideoObject)
 from savant_rs.primitives.geometry import BBox, RBBox
 
 from savant.api.constants import DEFAULT_NAMESPACE, DEFAULT_TIME_BASE

--- a/savant/api/parser.py
+++ b/savant/api/parser.py
@@ -1,12 +1,7 @@
 from typing import Tuple, Union
 
-from savant_rs.primitives import (
-    Attribute,
-    AttributeValue,
-    AttributeValueType,
-    VideoFrame,
-    VideoObject,
-)
+from savant_rs.primitives import (Attribute, AttributeValue,
+                                  AttributeValueType, VideoFrame, VideoObject)
 from savant_rs.primitives.geometry import BBox, RBBox
 from savant_rs.video_object_query import MatchQuery
 

--- a/savant/base/converter.py
+++ b/savant/base/converter.py
@@ -1,9 +1,11 @@
 """Base model output converters."""
 from abc import abstractmethod
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Optional, Tuple
+
 import numpy as np
+
+from savant.base.model import AttributeModel, ComplexModel, ObjectModel
 from savant.base.pyfunc import BasePyFuncCallableImpl
-from savant.base.model import ObjectModel, AttributeModel, ComplexModel
 
 
 class BaseObjectModelOutputConverter(BasePyFuncCallableImpl):

--- a/savant/base/input_preproc.py
+++ b/savant/base/input_preproc.py
@@ -1,17 +1,19 @@
 """Base model input preprocessors."""
 from abc import abstractmethod
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 import cv2
 import pyds
 from savant_rs.primitives.geometry import BBox
+
 from savant.base.model import OutputImage
-from savant.deepstream.cudastream import CudaStreams
-from savant.gstreamer import Gst
 from savant.base.pyfunc import BasePyFuncCallableImpl
+from savant.deepstream.cudastream import CudaStreams
 from savant.deepstream.meta.object import _NvDsObjectMetaImpl
 from savant.deepstream.opencv_utils import nvds_to_gpu_mat
-from savant.deepstream.utils import nvds_frame_meta_iterator, nvds_obj_meta_iterator
+from savant.deepstream.utils import (nvds_frame_meta_iterator,
+                                     nvds_obj_meta_iterator)
+from savant.gstreamer import Gst
 from savant.meta.object import ObjectMeta
 from savant.utils.image import GPUImage
 

--- a/savant/base/model.py
+++ b/savant/base/model.py
@@ -1,9 +1,11 @@
 """Base deep learning model configuration templates."""
-import cv2
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional, Tuple
+
+import cv2
 from omegaconf import MISSING
+
 from savant.base.pyfunc import PyFunc
 from savant.meta.constants import PRIMARY_OBJECT_KEY
 from savant.remote_file.schema import RemoteFile

--- a/savant/base/pyfunc.py
+++ b/savant/base/pyfunc.py
@@ -1,10 +1,12 @@
 """PyFunc definitions."""
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from importlib import util as importlib_util, import_module
+from importlib import import_module
+from importlib import util as importlib_util
 from pathlib import Path
 from typing import Any, Dict, Optional
-import logging
+
 from savant.gstreamer import Gst  # noqa: F401
 
 

--- a/savant/base/selector.py
+++ b/savant/base/selector.py
@@ -1,6 +1,8 @@
 """Base object selectors."""
 from abc import abstractmethod
+
 import numpy as np
+
 from savant.base.pyfunc import BasePyFuncCallableImpl
 
 

--- a/savant/config/__init__.py
+++ b/savant/config/__init__.py
@@ -1,9 +1,10 @@
 """Module configuration."""
 from omegaconf import OmegaConf
-from .module_config import ModuleConfig
-from .initializer_resolver import initializer_resolver
+
 from .calc_resolver import calc_resolver
+from .initializer_resolver import initializer_resolver
 from .json_resolver import json_resolver
+from .module_config import ModuleConfig
 
 OmegaConf.register_new_resolver('initializer', initializer_resolver)
 OmegaConf.register_new_resolver('calc', calc_resolver)

--- a/savant/config/initializer_resolver.py
+++ b/savant/config/initializer_resolver.py
@@ -1,10 +1,10 @@
 """Initializer resolver for OmegaConf."""
-import os
 import json
 import logging
+import os
 from typing import Any
-from savant.parameter_storage import param_storage, STORAGE_TYPES
 
+from savant.parameter_storage import STORAGE_TYPES, param_storage
 
 logger = logging.getLogger(__name__)
 

--- a/savant/config/json_resolver.py
+++ b/savant/config/json_resolver.py
@@ -1,8 +1,9 @@
 """JSON resolver for OmegaConf."""
-from typing import Optional, Union
 import json
 import logging
-from omegaconf import OmegaConf, DictConfig, ListConfig
+from typing import Optional, Union
+
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 logger = logging.getLogger(__name__)
 

--- a/savant/config/module_config.py
+++ b/savant/config/module_config.py
@@ -1,21 +1,15 @@
 """Module configuration."""
+import logging
 import re
 from pathlib import Path
-from typing import Callable, Optional, Union, Tuple, Dict, Type, Iterable, Any
-import logging
-from omegaconf import OmegaConf, DictConfig
-from savant.config.schema import (
-    BufferQueuesParameters,
-    Module,
-    Pipeline,
-    ElementGroup,
-    PipelineElement,
-    PyFuncElement,
-    ModelElement,
-    get_element_name,
-    DrawFunc,
-    FrameParameters,
-)
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union
+
+from omegaconf import DictConfig, OmegaConf
+
+from savant.config.schema import (BufferQueuesParameters, DrawFunc,
+                                  ElementGroup, FrameParameters, ModelElement,
+                                  Module, Pipeline, PipelineElement,
+                                  PyFuncElement, get_element_name)
 from savant.deepstream.nvinfer.element_config import nvinfer_configure_element
 from savant.parameter_storage import init_param_storage
 from savant.utils.singleton import SingletonMeta

--- a/savant/config/schema.py
+++ b/savant/config/schema.py
@@ -1,8 +1,10 @@
 """Module and pipeline elements configuration templates."""
+import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Union
-import json
+
 from omegaconf import MISSING, DictConfig, OmegaConf
+
 from savant.base.pyfunc import PyFunc
 
 

--- a/savant/converter/__init__.py
+++ b/savant/converter/__init__.py
@@ -1,3 +1,3 @@
 """Model output postprocessing."""
 from .classifier import TensorToLabelConverter
-from .vector_attribute import TensorToVectorConverter, TensorToItemConverter
+from .vector_attribute import TensorToItemConverter, TensorToVectorConverter

--- a/savant/converter/classifier.py
+++ b/savant/converter/classifier.py
@@ -1,6 +1,8 @@
 """Tensor to label converter."""
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
+
 import numpy as np
+
 from savant.base.converter import BaseAttributeModelOutputConverter
 from savant.base.model import AttributeModel
 

--- a/savant/converter/rapid.py
+++ b/savant/converter/rapid.py
@@ -1,8 +1,10 @@
 """Tensor to bounding box converter."""
 from typing import Tuple
+
 import numpy as np
+from numba import float32, njit, void
 from pysavantboost import nms
-from numba import njit, float32, void
+
 from savant.base.converter import BaseObjectModelOutputConverter
 from savant.base.model import ObjectModel
 

--- a/savant/converter/vector_attribute.py
+++ b/savant/converter/vector_attribute.py
@@ -1,6 +1,8 @@
 """Tensor to vector converters."""
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
+
 import numpy as np
+
 from savant.base.converter import BaseAttributeModelOutputConverter
 from savant.base.model import AttributeModel
 

--- a/savant/converter/yolo.py
+++ b/savant/converter/yolo.py
@@ -2,7 +2,9 @@
 TODO: Add `symmetric-padding` support.
 """
 from typing import Tuple
+
 import numpy as np
+
 from savant.base.converter import BaseObjectModelOutputConverter
 from savant.base.model import ObjectModel
 

--- a/savant/converter/yolo_v4.py
+++ b/savant/converter/yolo_v4.py
@@ -3,7 +3,9 @@
 Based on code from https://github.com/Tianxiaomo/pytorch-YOLOv4
 """
 from typing import Tuple
+
 import numpy as np
+
 from savant.base.converter import BaseObjectModelOutputConverter
 from savant.base.model import ObjectModel
 

--- a/savant/converter/yolo_v5face.py
+++ b/savant/converter/yolo_v5face.py
@@ -2,12 +2,13 @@
 
 Based on code from https://github.com/deepcam-cn/yolov5-face>
 """
-from typing import Tuple, Any
+from typing import Any, Tuple
+
 import numpy as np
-from savant.base.converter import BaseComplexModelOutputConverter
-from savant.base.model import ComplexModel
 from numba.typed import List
 
+from savant.base.converter import BaseComplexModelOutputConverter
+from savant.base.model import ComplexModel
 from savant.selector.detector import nms_cpu
 
 

--- a/savant/converter/yolo_x.py
+++ b/savant/converter/yolo_x.py
@@ -1,9 +1,12 @@
 """YOLOX detector postprocessing (converter)."""
-from typing import Tuple
 from functools import lru_cache
+from typing import Tuple
+
 import numpy as np
-from savant.converter.yolo import TensorToBBoxConverter as YoloTensorToBBoxConverter
+
 from savant.base.model import ObjectModel
+from savant.converter.yolo import \
+    TensorToBBoxConverter as YoloTensorToBBoxConverter
 
 
 class TensorToBBoxConverter(YoloTensorToBBoxConverter):

--- a/savant/deepstream/buffer_processor.py
+++ b/savant/deepstream/buffer_processor.py
@@ -1,65 +1,54 @@
 """Buffer processor for DeepStream pipeline."""
+import logging
 from collections import deque
 from heapq import heappop, heappush
 from queue import Queue
-from typing import Deque, Dict, List, Tuple
+from typing import (Deque, Dict, Iterator, List, NamedTuple, Optional, Tuple,
+                    Union)
 
-from typing import Optional, Union, NamedTuple, Iterator
-import logging
 import numpy as np
 import pyds
-from pygstsavantframemeta import (
-    gst_buffer_get_savant_frame_meta,
-    nvds_frame_meta_get_nvds_savant_frame_meta,
-)
+from pygstsavantframemeta import (gst_buffer_get_savant_frame_meta,
+                                  nvds_frame_meta_get_nvds_savant_frame_meta)
 from savant_rs.primitives.geometry import BBox, RBBox
-from savant_rs.utils.symbol_mapper import (
-    parse_compound_key,
-    get_model_id,
-    get_object_id,
-    build_model_object_key,
-)
+from savant_rs.utils.symbol_mapper import (build_model_object_key,
+                                           get_model_id, get_object_id,
+                                           parse_compound_key)
 
 from savant.base.input_preproc import ObjectsPreprocessing
-from savant.base.model import ObjectModel, ComplexModel
+from savant.base.model import ComplexModel, ObjectModel
+from savant.config.schema import FrameParameters, ModelElement, PipelineElement
 from savant.deepstream.meta.object import _NvDsObjectMetaImpl
-from savant.deepstream.source_output import (
-    SourceOutput,
-    SourceOutputEncoded,
-    SourceOutputH26X,
-    SourceOutputWithFrame,
-)
+from savant.deepstream.nvinfer.model import (NvInferAttributeModel,
+                                             NvInferDetector)
+from savant.deepstream.source_output import (SourceOutput, SourceOutputEncoded,
+                                             SourceOutputH26X,
+                                             SourceOutputWithFrame)
+from savant.deepstream.utils import (get_nvds_buf_surface,
+                                     nvds_add_attr_meta_to_obj,
+                                     nvds_add_obj_meta_to_frame,
+                                     nvds_clf_meta_iterator,
+                                     nvds_frame_meta_iterator,
+                                     nvds_infer_tensor_meta_to_outputs,
+                                     nvds_label_info_iterator,
+                                     nvds_obj_meta_iterator,
+                                     nvds_set_obj_selection_type,
+                                     nvds_set_obj_uid,
+                                     nvds_tensor_output_iterator)
 from savant.deepstream.utils.attribute import nvds_get_all_obj_attrs
-from savant.meta.constants import PRIMARY_OBJECT_KEY
-from savant.config.schema import PipelineElement, ModelElement, FrameParameters
-from savant.deepstream.nvinfer.model import (
-    NvInferDetector,
-    NvInferAttributeModel,
-)
-from savant.deepstream.utils import (
-    get_nvds_buf_surface,
-    nvds_frame_meta_iterator,
-    nvds_obj_meta_iterator,
-    nvds_clf_meta_iterator,
-    nvds_label_info_iterator,
-    nvds_tensor_output_iterator,
-    nvds_infer_tensor_meta_to_outputs,
-    nvds_add_obj_meta_to_frame,
-    nvds_add_attr_meta_to_obj,
-    nvds_set_obj_selection_type,
-    nvds_set_obj_uid,
-)
 from savant.gstreamer import Gst  # noqa:F401
 from savant.gstreamer.buffer_processor import GstBufferProcessor
-from savant.gstreamer.codecs import CodecInfo, Codec
-from savant.gstreamer.metadata import get_source_frame_meta, metadata_pop_frame_meta
+from savant.gstreamer.codecs import Codec, CodecInfo
+from savant.gstreamer.metadata import (get_source_frame_meta,
+                                       metadata_pop_frame_meta)
+from savant.meta.constants import PRIMARY_OBJECT_KEY
 from savant.meta.object import ObjectMeta
 from savant.meta.type import ObjectSelectionType
 from savant.utils.fps_meter import FPSMeter
 from savant.utils.logging import LoggerMixin
 from savant.utils.platform import is_aarch64
 from savant.utils.sink_factories import SinkVideoFrame
-from savant.utils.source_info import SourceInfoRegistry, SourceInfo
+from savant.utils.source_info import SourceInfo, SourceInfoRegistry
 
 
 class _OutputFrame(NamedTuple):

--- a/savant/deepstream/cudastream.py
+++ b/savant/deepstream/cudastream.py
@@ -1,4 +1,5 @@
 import cv2
+
 from savant.deepstream.meta.frame import NvDsFrameMeta
 from savant.utils.logging import LoggerMixin
 

--- a/savant/deepstream/drawfunc.py
+++ b/savant/deepstream/drawfunc.py
@@ -1,22 +1,19 @@
 """Default implementation PyFunc for drawing on frame."""
 from typing import Any, Dict, Optional
+
 import cv2
-from savant_rs.draw_spec import (
-    ObjectDraw,
-    LabelDraw,
-    BoundingBoxDraw,
-    DotDraw,
-    LabelPositionKind,
-)
+from savant_rs.draw_spec import (BoundingBoxDraw, DotDraw, LabelDraw,
+                                 LabelPositionKind, ObjectDraw)
 from savant_rs.primitives.geometry import RBBox
-from savant.meta.object import ObjectMeta
+
 from savant.deepstream.base_drawfunc import BaseNvDsDrawFunc
 from savant.deepstream.meta.frame import NvDsFrameMeta
-from savant.meta.constants import UNTRACKED_OBJECT_ID
-from savant.utils.artist import Position, Artist
-from savant.utils.draw_spec import get_obj_draw_spec, get_default_draw_spec
-from savant.gstreamer import Gst  # noqa: F401
 from savant.deepstream.opencv_utils import nvds_to_gpu_mat
+from savant.gstreamer import Gst  # noqa: F401
+from savant.meta.constants import UNTRACKED_OBJECT_ID
+from savant.meta.object import ObjectMeta
+from savant.utils.artist import Artist, Position
+from savant.utils.draw_spec import get_default_draw_spec, get_obj_draw_spec
 
 
 class NvDsDrawFunc(BaseNvDsDrawFunc):

--- a/savant/deepstream/meta/frame.py
+++ b/savant/deepstream/meta/frame.py
@@ -1,20 +1,18 @@
 """Wrapper of deepstream frame meta information."""
-from typing import Iterator, Optional, Dict
 from contextlib import AbstractContextManager
-import pyds
-from savant_rs.primitives.geometry import BBox
-from savant.gstreamer.metadata import (
-    get_source_frame_meta,
-    SourceFrameMeta,
-    OnlyExtendedDict,
-)
-from savant.meta.errors import MetaValueError
-from savant.deepstream.meta.object import _NvDsObjectMetaImpl
+from typing import Dict, Iterator, Optional
 
-from savant.meta.object import ObjectMeta
-from savant.utils.source_info import SourceInfoRegistry
-from savant.utils.logging import LoggerMixin
+import pyds
 from pygstsavantframemeta import nvds_frame_meta_get_nvds_savant_frame_meta
+from savant_rs.primitives.geometry import BBox
+
+from savant.deepstream.meta.object import _NvDsObjectMetaImpl
+from savant.gstreamer.metadata import (OnlyExtendedDict, SourceFrameMeta,
+                                       get_source_frame_meta)
+from savant.meta.errors import MetaValueError
+from savant.meta.object import ObjectMeta
+from savant.utils.logging import LoggerMixin
+from savant.utils.source_info import SourceInfoRegistry
 
 
 def nvds_obj_meta_generator(

--- a/savant/deepstream/meta/object.py
+++ b/savant/deepstream/meta/object.py
@@ -1,38 +1,29 @@
 """Deepstream-specific ObjectMeta interface implementation."""
-from typing import Any, List, Optional, Union
 import logging
-import pyds
-from savant_rs.utils.symbol_mapper import (
-    parse_compound_key,
-    get_object_id,
-    build_model_object_key,
-    get_model_name,
-)
-from savant_rs.primitives.geometry import BBox, RBBox
+from typing import Any, List, Optional, Union
 
-from savant.deepstream.utils.object import nvds_is_empty_object_meta
-from savant.meta.errors import MetaValueError
+import pyds
+from savant_rs.primitives.geometry import BBox, RBBox
+from savant_rs.utils.symbol_mapper import (build_model_object_key,
+                                           get_model_name, get_object_id,
+                                           parse_compound_key)
+
 from savant.deepstream.meta.constants import MAX_LABEL_SIZE
-from savant.deepstream.utils import (
-    nvds_get_obj_attr_meta,
-    nvds_get_obj_attr_meta_list,
-    nvds_add_attr_meta_to_obj,
-    nvds_set_obj_uid,
-    nvds_get_obj_uid,
-    nvds_set_obj_draw_label,
-    nvds_get_obj_draw_label,
-    nvds_init_obj_draw_label,
-    nvds_get_obj_bbox,
-    nvds_set_obj_bbox,
-    nvds_upd_obj_bbox,
-)
-from savant.utils.logging import LoggerMixin
+from savant.deepstream.utils import (nvds_add_attr_meta_to_obj,
+                                     nvds_get_obj_attr_meta,
+                                     nvds_get_obj_attr_meta_list,
+                                     nvds_get_obj_bbox,
+                                     nvds_get_obj_draw_label, nvds_get_obj_uid,
+                                     nvds_init_obj_draw_label,
+                                     nvds_set_obj_bbox,
+                                     nvds_set_obj_draw_label, nvds_set_obj_uid,
+                                     nvds_upd_obj_bbox)
+from savant.deepstream.utils.object import nvds_is_empty_object_meta
 from savant.meta.attribute import AttributeMeta
-from savant.meta.constants import (
-    UNTRACKED_OBJECT_ID,
-    DEFAULT_CONFIDENCE,
-)
-from savant.meta.object import ObjectMeta, BaseObjectMetaImpl
+from savant.meta.constants import DEFAULT_CONFIDENCE, UNTRACKED_OBJECT_ID
+from savant.meta.errors import MetaValueError
+from savant.meta.object import BaseObjectMetaImpl, ObjectMeta
+from savant.utils.logging import LoggerMixin
 
 
 class _NvDsObjectMetaImpl(BaseObjectMetaImpl, LoggerMixin):

--- a/savant/deepstream/metadata.py
+++ b/savant/deepstream/metadata.py
@@ -1,10 +1,11 @@
 """Convert deepstream object meta to output format."""
-from typing import Any, Dict
 import logging
+from typing import Any, Dict
+
 import pyds
+from savant_rs.primitives.geometry import RBBox
 from savant_rs.utils.symbol_mapper import parse_compound_key
 
-from savant_rs.primitives.geometry import RBBox
 from savant.config.schema import FrameParameters
 from savant.deepstream.utils import nvds_get_obj_bbox
 from savant.deepstream.utils.object import nvds_is_empty_object_meta

--- a/savant/deepstream/nvinfer/element_config.py
+++ b/savant/deepstream/nvinfer/element_config.py
@@ -1,33 +1,25 @@
 """`nvinfer` element configuration."""
-from pathlib import Path
-from typing import Type, Optional
 import logging
-from omegaconf import OmegaConf, DictConfig
-from savant_rs.utils.symbol_mapper import (
-    register_model_objects,
-    RegistrationPolicy,
-    parse_compound_key,
-    get_object_id,
-)
+from pathlib import Path
+from typing import Optional, Type
 
-from savant.base.model import (
-    ModelPrecision,
-    ObjectModel,
-    AttributeModel,
-    ModelColorFormat,
-)
+from omegaconf import DictConfig, OmegaConf
+from savant_rs.utils.symbol_mapper import (RegistrationPolicy, get_object_id,
+                                           parse_compound_key,
+                                           register_model_objects)
+
+from savant.base.model import (AttributeModel, ModelColorFormat,
+                               ModelPrecision, ObjectModel)
 from savant.config.schema import get_element_name
+from savant.deepstream.nvinfer.file_config import (NvInferConfig,
+                                                   NvInferConfigType)
+from savant.deepstream.nvinfer.model import (NVINFER_MODEL_TYPE_REGISTRY,
+                                             NvInferInstanceSegmentation,
+                                             NvInferModel, NvInferModelFormat,
+                                             NvInferModelType,
+                                             NvInferObjectModelOutputObject)
 from savant.parameter_storage import param_storage
 from savant.remote_file import process_remote
-from savant.deepstream.nvinfer.file_config import NvInferConfig, NvInferConfigType
-from savant.deepstream.nvinfer.model import (
-    NVINFER_MODEL_TYPE_REGISTRY,
-    NvInferModelFormat,
-    NvInferModelType,
-    NvInferObjectModelOutputObject,
-    NvInferModel,
-    NvInferInstanceSegmentation,
-)
 
 __all__ = ['nvinfer_configure_element']
 

--- a/savant/deepstream/nvinfer/file_config.py
+++ b/savant/deepstream/nvinfer/file_config.py
@@ -1,27 +1,19 @@
 """Gst-nvinfer file configuration."""
+import copy
+import re
+from configparser import ConfigParser
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    MutableSequence,
-    Optional,
-    Union,
-)
-from configparser import ConfigParser
-import copy
-import re
+from typing import (Any, Callable, Dict, List, Mapping, MutableSequence,
+                    Optional, Union)
+
 from omegaconf import DictConfig
-from savant.base.model import ModelPrecision, ModelColorFormat
-from .model import (
-    NVINFER_DEFAULT_OBJECT_SELECTOR,
-    NvInferModelFormat,
-    NvInferModel,
-)
+
+from savant.base.model import ModelColorFormat, ModelPrecision
+
+from .model import (NVINFER_DEFAULT_OBJECT_SELECTOR, NvInferModel,
+                    NvInferModelFormat)
 
 __all__ = ['NvInferConfig', 'NvInferConfigType']
 

--- a/savant/deepstream/nvinfer/model.py
+++ b/savant/deepstream/nvinfer/model.py
@@ -2,17 +2,13 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
+
 from omegaconf import MISSING
+
+from savant.base.model import (AttributeModel, ComplexModel, Model, ModelInput,
+                               ObjectModel, ObjectModelOutput,
+                               ObjectModelOutputObject)
 from savant.base.pyfunc import PyFunc
-from savant.base.model import (
-    Model,
-    ModelInput,
-    ObjectModel,
-    ObjectModelOutput,
-    ObjectModelOutputObject,
-    AttributeModel,
-    ComplexModel,
-)
 from savant.utils.registry import Registry
 
 NVINFER_MODEL_TYPE_REGISTRY = Registry('nvinfer_model_type')

--- a/savant/deepstream/opencv_utils.py
+++ b/savant/deepstream/opencv_utils.py
@@ -1,7 +1,7 @@
 """Utils for working OpenCV representation of CUDA memory (cv2.cuda.GpuMat)."""
 
 from contextlib import contextmanager
-from typing import ContextManager, Tuple, Union, Optional
+from typing import ContextManager, Optional, Tuple, Union
 
 import cv2
 import numpy as np

--- a/savant/deepstream/pipeline.py
+++ b/savant/deepstream/pipeline.py
@@ -1,64 +1,45 @@
 """DeepStream pipeline."""
+import logging
+import time
 from collections import defaultdict
 from pathlib import Path
 from queue import Queue
 from threading import Lock
 from typing import Any, List, Optional, Tuple
-import time
-import logging
+
 import pyds
+from pygstsavantframemeta import (add_convert_savant_frame_meta_pad_probe,
+                                  nvds_frame_meta_get_nvds_savant_frame_meta)
 from savant_rs.primitives.geometry import BBox
 
 from savant.base.input_preproc import ObjectsPreprocessing
-
-from pygstsavantframemeta import (
-    add_convert_savant_frame_meta_pad_probe,
-    nvds_frame_meta_get_nvds_savant_frame_meta,
-)
-
-from savant.deepstream.buffer_processor import (
-    NvDsBufferProcessor,
-    create_buffer_processor,
-)
-from savant.deepstream.source_output import (
-    SourceOutputWithFrame,
-    create_source_output,
-)
-from savant.deepstream.utils.pipeline import add_queues_to_pipeline
-from savant.gstreamer import Gst, GLib  # noqa:F401
-from savant.gstreamer.pipeline import GstPipeline
-from savant.deepstream.metadata import (
-    nvds_obj_meta_output_converter,
-    nvds_attr_meta_output_converter,
-)
-from savant.gstreamer.metadata import (
-    SourceFrameMeta,
-    metadata_add_frame_meta,
-    get_source_frame_meta,
-)
-from savant.gstreamer.utils import on_pad_event, pad_to_source_id
-from savant.deepstream.utils import (
-    gst_nvevent_parse_stream_eos,
-    GST_NVEVENT_STREAM_EOS,
-    nvds_frame_meta_iterator,
-    nvds_obj_meta_iterator,
-    nvds_attr_meta_iterator,
-    nvds_remove_obj_attrs,
-)
-from savant.meta.constants import UNTRACKED_OBJECT_ID, PRIMARY_OBJECT_KEY
-from savant.utils.fps_meter import FPSMeter
-from savant.utils.source_info import SourceInfoRegistry, SourceInfo, Resolution
-from savant.utils.platform import is_aarch64
-from savant.config.schema import (
-    BufferQueuesParameters,
-    Pipeline,
-    PipelineElement,
-    ModelElement,
-    FrameParameters,
-    DrawFunc,
-)
 from savant.base.model import AttributeModel, ComplexModel
+from savant.config.schema import (BufferQueuesParameters, DrawFunc,
+                                  FrameParameters, ModelElement, Pipeline,
+                                  PipelineElement)
+from savant.deepstream.buffer_processor import (NvDsBufferProcessor,
+                                                create_buffer_processor)
+from savant.deepstream.metadata import (nvds_attr_meta_output_converter,
+                                        nvds_obj_meta_output_converter)
+from savant.deepstream.source_output import (SourceOutputWithFrame,
+                                             create_source_output)
+from savant.deepstream.utils import (GST_NVEVENT_STREAM_EOS,
+                                     gst_nvevent_parse_stream_eos,
+                                     nvds_attr_meta_iterator,
+                                     nvds_frame_meta_iterator,
+                                     nvds_obj_meta_iterator,
+                                     nvds_remove_obj_attrs)
+from savant.deepstream.utils.pipeline import add_queues_to_pipeline
+from savant.gstreamer import GLib, Gst  # noqa:F401
+from savant.gstreamer.metadata import (SourceFrameMeta, get_source_frame_meta,
+                                       metadata_add_frame_meta)
+from savant.gstreamer.pipeline import GstPipeline
+from savant.gstreamer.utils import on_pad_event, pad_to_source_id
+from savant.meta.constants import PRIMARY_OBJECT_KEY, UNTRACKED_OBJECT_ID
+from savant.utils.fps_meter import FPSMeter
+from savant.utils.platform import is_aarch64
 from savant.utils.sink_factories import SinkEndOfStream
+from savant.utils.source_info import Resolution, SourceInfo, SourceInfoRegistry
 
 
 class NvDsPipeline(GstPipeline):

--- a/savant/deepstream/pyfunc.py
+++ b/savant/deepstream/pyfunc.py
@@ -1,17 +1,16 @@
 """Base implementation of user-defined PyFunc class."""
-import pyds
 import cv2
+import pyds
+
 from savant.base.pyfunc import BasePyFuncPlugin
-from savant.deepstream.utils import (
-    nvds_frame_meta_iterator,
-    GST_NVEVENT_PAD_ADDED,
-    GST_NVEVENT_PAD_DELETED,
-    GST_NVEVENT_STREAM_EOS,
-    gst_nvevent_parse_pad_added,
-    gst_nvevent_parse_pad_deleted,
-    gst_nvevent_parse_stream_eos,
-)
 from savant.deepstream.meta.frame import NvDsFrameMeta
+from savant.deepstream.utils import (GST_NVEVENT_PAD_ADDED,
+                                     GST_NVEVENT_PAD_DELETED,
+                                     GST_NVEVENT_STREAM_EOS,
+                                     gst_nvevent_parse_pad_added,
+                                     gst_nvevent_parse_pad_deleted,
+                                     gst_nvevent_parse_stream_eos,
+                                     nvds_frame_meta_iterator)
 from savant.gstreamer import Gst  # noqa: F401
 from savant.utils.source_info import SourceInfoRegistry
 

--- a/savant/deepstream/source_output.py
+++ b/savant/deepstream/source_output.py
@@ -1,16 +1,13 @@
 """Classes for adding output elements to a DeepStream pipeline."""
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import pyds
 from pygstsavantframemeta import add_convert_savant_frame_meta_pad_probe
 
-from savant.config.schema import (
-    FrameProcessingCondition,
-    PipelineElement,
-    FrameParameters,
-)
+from savant.config.schema import (FrameParameters, FrameProcessingCondition,
+                                  PipelineElement)
 from savant.gstreamer import Gst  # noqa:F401
 from savant.gstreamer.codecs import CODEC_BY_NAME, Codec, CodecInfo
 from savant.gstreamer.pipeline import GstPipeline

--- a/savant/deepstream/utils/__init__.py
+++ b/savant/deepstream/utils/__init__.py
@@ -1,47 +1,23 @@
-from .attribute import (
-    nvds_add_attr_meta_to_obj,
-    nvds_attr_meta_iterator,
-    nvds_get_obj_attr_meta_list,
-    nvds_get_obj_attr_meta,
-    nvds_remove_obj_attrs,
-)
-from .event import (
-    GST_NVEVENT_PAD_ADDED,
-    GST_NVEVENT_PAD_DELETED,
-    GST_NVEVENT_STREAM_EOS,
-    GST_NVEVENT_STREAM_SEGMENT,
-    GST_NVEVENT_STREAM_RESET,
-    GST_NVEVENT_STREAM_START,
-    GST_NVEVENT_ROI_UPDATE,
-    GST_NVEVENT_INFER_INTERVAL_UPDATE,
-    gst_event_type_to_str,
-    gst_nvevent_parse_pad_added,
-    gst_nvevent_parse_pad_deleted,
-    gst_nvevent_new_stream_eos,
-    gst_nvevent_parse_stream_eos,
-    gst_nvevent_parse_stream_start,
-)
-from .iterator import (
-    nvds_frame_meta_iterator,
-    nvds_batch_user_meta_iterator,
-    nvds_frame_user_meta_iterator,
-    nvds_obj_meta_iterator,
-    nvds_clf_meta_iterator,
-    nvds_label_info_iterator,
-    nvds_tensor_output_iterator,
-)
-from .object import (
-    nvds_add_obj_meta_to_frame,
-    nvds_set_obj_selection_type,
-    nvds_get_obj_selection_type,
-    nvds_set_obj_uid,
-    nvds_get_obj_uid,
-    nvds_get_obj_bbox,
-    nvds_set_obj_bbox,
-    nvds_upd_obj_bbox,
-    nvds_set_obj_draw_label,
-    nvds_get_obj_draw_label,
-    nvds_init_obj_draw_label,
-)
+from .attribute import (nvds_add_attr_meta_to_obj, nvds_attr_meta_iterator,
+                        nvds_get_obj_attr_meta, nvds_get_obj_attr_meta_list,
+                        nvds_remove_obj_attrs)
+from .event import (GST_NVEVENT_INFER_INTERVAL_UPDATE, GST_NVEVENT_PAD_ADDED,
+                    GST_NVEVENT_PAD_DELETED, GST_NVEVENT_ROI_UPDATE,
+                    GST_NVEVENT_STREAM_EOS, GST_NVEVENT_STREAM_RESET,
+                    GST_NVEVENT_STREAM_SEGMENT, GST_NVEVENT_STREAM_START,
+                    gst_event_type_to_str, gst_nvevent_new_stream_eos,
+                    gst_nvevent_parse_pad_added, gst_nvevent_parse_pad_deleted,
+                    gst_nvevent_parse_stream_eos,
+                    gst_nvevent_parse_stream_start)
+from .iterator import (nvds_batch_user_meta_iterator, nvds_clf_meta_iterator,
+                       nvds_frame_meta_iterator, nvds_frame_user_meta_iterator,
+                       nvds_label_info_iterator, nvds_obj_meta_iterator,
+                       nvds_tensor_output_iterator)
+from .object import (nvds_add_obj_meta_to_frame, nvds_get_obj_bbox,
+                     nvds_get_obj_draw_label, nvds_get_obj_selection_type,
+                     nvds_get_obj_uid, nvds_init_obj_draw_label,
+                     nvds_set_obj_bbox, nvds_set_obj_draw_label,
+                     nvds_set_obj_selection_type, nvds_set_obj_uid,
+                     nvds_upd_obj_bbox)
 from .surface import get_nvds_buf_surface
 from .tensor import nvds_infer_tensor_meta_to_outputs

--- a/savant/deepstream/utils/attribute.py
+++ b/savant/deepstream/utils/attribute.py
@@ -1,9 +1,11 @@
 """DeepStream object attribute utils."""
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-import pyds
-from savant.meta.attribute import AttributeMeta
-from .object import nvds_get_obj_uid
 
+import pyds
+
+from savant.meta.attribute import AttributeMeta
+
+from .object import nvds_get_obj_uid
 
 # attribute storage, workaround
 NVDS_OBJ_ATTR_STORAGE: Dict[int, Dict[Tuple[str, str], List[AttributeMeta]]] = {}

--- a/savant/deepstream/utils/event.py
+++ b/savant/deepstream/utils/event.py
@@ -8,7 +8,8 @@ https://docs.nvidia.com/metropolis/deepstream/dev-guide/sdk-api/group__gstreamer
   defines GstNvCustomEventType and create/parse functions
 """
 import ctypes
-from savant.gstreamer import Gst, GObject  # noqa:F401
+
+from savant.gstreamer import GObject, Gst  # noqa:F401
 
 
 def _make_nvevent_type(event_type: int):

--- a/savant/deepstream/utils/iterator.py
+++ b/savant/deepstream/utils/iterator.py
@@ -1,5 +1,6 @@
 """DeepStream iterators."""
 from typing import Any, Callable, Optional, Union
+
 import pyds
 
 

--- a/savant/deepstream/utils/object.py
+++ b/savant/deepstream/utils/object.py
@@ -1,17 +1,16 @@
 """DeepStream object utils."""
 from typing import Optional, Tuple, Union
+
 import pyds
+from pysavantboost import NvRBboxCoords, add_rbbox_to_object_meta, get_rbbox
 from savant_rs.primitives.geometry import BBox, RBBox
-from pysavantboost import add_rbbox_to_object_meta, NvRBboxCoords, get_rbbox
-from savant.meta.errors import (
-    IncorrectSelectionType,
-    UIDError,
-    MetaPoolError,
-    MetaValueError,
-)
-from savant.meta.constants import UNTRACKED_OBJECT_ID, DEFAULT_CONFIDENCE
-from savant.meta.type import InformationType, ObjectSelectionType
+
 from savant.deepstream.meta.constants import MAX_LABEL_SIZE
+from savant.meta.constants import DEFAULT_CONFIDENCE, UNTRACKED_OBJECT_ID
+from savant.meta.errors import (IncorrectSelectionType, MetaPoolError,
+                                MetaValueError, UIDError)
+from savant.meta.type import InformationType, ObjectSelectionType
+
 from .iterator import nvds_obj_user_meta_iterator
 from .meta_types import OBJ_DRAW_LABEL_META_TYPE
 

--- a/savant/deepstream/utils/pipeline.py
+++ b/savant/deepstream/utils/pipeline.py
@@ -1,12 +1,7 @@
 from typing import Any, Dict, Union
 
-from savant.config.schema import (
-    BufferQueuesParameters,
-    ElementGroup,
-    Pipeline,
-    PipelineElement,
-    PyFuncElement,
-)
+from savant.config.schema import (BufferQueuesParameters, ElementGroup,
+                                  Pipeline, PipelineElement, PyFuncElement)
 
 
 def add_queues_to_pipeline(

--- a/savant/deepstream/utils/surface.py
+++ b/savant/deepstream/utils/surface.py
@@ -1,8 +1,10 @@
 """DeepStream surface utils."""
 from contextlib import contextmanager
 from typing import ContextManager
-import pyds
+
 import numpy as np
+import pyds
+
 from savant.gstreamer import Gst  # noqa:F401
 
 

--- a/savant/deepstream/utils/tensor.py
+++ b/savant/deepstream/utils/tensor.py
@@ -1,8 +1,9 @@
 """DeepStream tensor utils."""
-from typing import List, Optional
 import ctypes
-import pyds
+from typing import List, Optional
+
 import numpy as np
+import pyds
 
 
 def nvds_infer_tensor_meta_to_outputs(

--- a/savant/entrypoint/__main__.py
+++ b/savant/entrypoint/__main__.py
@@ -3,6 +3,7 @@
 >>> python -m savant.entrypoint {config_file_path}
 """
 import sys
+
 from savant.entrypoint.main import main
 
 if __name__ == '__main__':

--- a/savant/entrypoint/main.py
+++ b/savant/entrypoint/main.py
@@ -2,11 +2,11 @@
 import os
 
 from savant.config import ModuleConfig
-from savant.gstreamer import Gst
 from savant.deepstream.encoding import check_encoder_is_available
 from savant.deepstream.pipeline import NvDsPipeline
 from savant.deepstream.runner import NvDsPipelineRunner
-from savant.utils.logging import init_logging, update_logging, get_logger
+from savant.gstreamer import Gst
+from savant.utils.logging import get_logger, init_logging, update_logging
 from savant.utils.sink_factories import sink_factory
 
 

--- a/savant/gstreamer/__init__.py
+++ b/savant/gstreamer/__init__.py
@@ -10,10 +10,4 @@ gi.require_version('GstApp', '1.0')
 gi.require_version('GstVideo', '1.0')
 
 # pylint:disable=wrong-import-position
-from gi.repository import (
-    GObject,
-    GLib,
-    Gst,
-    GstBase,
-    GstApp,
-)
+from gi.repository import GLib, GObject, Gst, GstApp, GstBase

--- a/savant/gstreamer/element_factory.py
+++ b/savant/gstreamer/element_factory.py
@@ -1,6 +1,8 @@
 """GStreamer pipeline elements factory."""
 from typing import Any
+
 from gi.repository import Gst  # noqa:F401
+
 from savant.config.schema import PipelineElement
 from savant.parameter_storage import param_storage
 

--- a/savant/gstreamer/metadata.py
+++ b/savant/gstreamer/metadata.py
@@ -1,6 +1,6 @@
 """Gstreamer metadata."""
 import logging
-from collections import defaultdict, UserDict
+from collections import UserDict, defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 

--- a/savant/gstreamer/pipeline.py
+++ b/savant/gstreamer/pipeline.py
@@ -1,19 +1,18 @@
 """GStreamer base pipeline."""
-from queue import Queue, Empty as EmptyException
-from typing import Any, List, Generator, Optional, Tuple
 import logging
+from queue import Empty as EmptyException
+from queue import Queue
+from typing import Any, Generator, List, Optional, Tuple
+
 from gi.repository import Gst  # noqa:F401
 
+from savant.config.schema import (ElementGroup, ModelElement, Pipeline,
+                                  PipelineElement)
 from savant.gstreamer.buffer_processor import GstBufferProcessor
-from savant.config.schema import (
-    PipelineElement,
-    Pipeline,
-    ModelElement,
-    ElementGroup,
-)
-from savant.utils.sink_factories import SinkMessage
+from savant.gstreamer.element_factory import (CreateElementException,
+                                              GstElementFactory)
 from savant.utils.fps_meter import FPSMeter
-from savant.gstreamer.element_factory import CreateElementException, GstElementFactory
+from savant.utils.sink_factories import SinkMessage
 
 
 class GstPipeline:  # pylint: disable=too-many-instance-attributes

--- a/savant/gstreamer/runner.py
+++ b/savant/gstreamer/runner.py
@@ -1,11 +1,13 @@
 """GStreamer pipeline runner class."""
-from datetime import timedelta
-from time import time
-from typing import Optional, Union
 import logging
 import os
 import threading
+from datetime import timedelta
+from time import time
+from typing import Optional, Union
+
 from gi.repository import GLib, Gst  # noqa:F401
+
 from .pipeline import GstPipeline
 
 logger = logging.getLogger(__name__)

--- a/savant/input_preproc/crop.py
+++ b/savant/input_preproc/crop.py
@@ -1,5 +1,6 @@
 """Model input metadata preprocessing: cropping variations."""
 from savant_rs.primitives.geometry import BBox
+
 from savant.base.input_preproc import BasePreprocessObjectMeta
 from savant.meta.object import ObjectMeta
 

--- a/savant/meta/attribute.py
+++ b/savant/meta/attribute.py
@@ -1,6 +1,6 @@
 """Attribute metadata."""
-from typing import Any
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass

--- a/savant/meta/object.py
+++ b/savant/meta/object.py
@@ -1,16 +1,12 @@
 """Object meta."""
 from abc import ABC, abstractmethod
-from typing import Optional, Any, List, Union
+from typing import Any, List, Optional, Union
 
 from savant_rs.primitives.geometry import BBox, RBBox
 
 from savant.meta.attribute import AttributeMeta
-from savant.meta.constants import (
-    UNTRACKED_OBJECT_ID,
-    DEFAULT_CONFIDENCE,
-    PRIMARY_OBJECT_LABEL,
-    DEFAULT_MODEL_NAME,
-)
+from savant.meta.constants import (DEFAULT_CONFIDENCE, DEFAULT_MODEL_NAME,
+                                   PRIMARY_OBJECT_LABEL, UNTRACKED_OBJECT_ID)
 
 
 class BaseObjectMetaImpl(ABC):

--- a/savant/parameter_storage/__init__.py
+++ b/savant/parameter_storage/__init__.py
@@ -1,10 +1,11 @@
 """Parameter storage package."""
-from typing import Optional
 import logging
-from omegaconf import OmegaConf, DictConfig
+from typing import Optional
+
+from omegaconf import DictConfig, OmegaConf
+
 from .etcd_storage import EtcdStorage, EtcdStorageConfig
 from .parameter_storage import ParameterStorage
-
 
 __all__ = ['param_storage', 'init_param_storage', 'STORAGE_TYPES']
 

--- a/savant/parameter_storage/etcd_storage.py
+++ b/savant/parameter_storage/etcd_storage.py
@@ -1,10 +1,12 @@
 """Etcd storage module."""
-from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Union
 import json
 import logging
-from omegaconf import MISSING
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Union
+
 import etcd3
+from omegaconf import MISSING
+
 from .parameter_storage import ParameterStorage
 
 logger = logging.getLogger(__name__)

--- a/savant/remote_file/__init__.py
+++ b/savant/remote_file/__init__.py
@@ -1,14 +1,15 @@
 """Remote file management."""
-from typing import Union
-from pathlib import Path
 import logging
+from pathlib import Path
+from typing import Union
+
 from omegaconf import DictConfig, OmegaConf
-from savant.remote_file.schema import RemoteFile
-from savant.remote_file.base import RemoteFileManagerType, RemoteFileError
+
+from savant.remote_file.base import RemoteFileError, RemoteFileManagerType
 from savant.remote_file.http import HTTPFileHandler
 from savant.remote_file.s3 import S3FileHandler
-from savant.remote_file.utils import unpack_archive, read_file_checksum
-
+from savant.remote_file.schema import RemoteFile
+from savant.remote_file.utils import read_file_checksum, unpack_archive
 
 __all__ = ['process_remote', 'RemoteFile']
 

--- a/savant/remote_file/base.py
+++ b/savant/remote_file/base.py
@@ -1,12 +1,13 @@
 """Base classes for remote file managing."""
-from abc import ABC, abstractmethod
-from typing import Optional, Set, FrozenSet, Type, Union
-from pathlib import Path
-from urllib.parse import urlparse
 import logging
-from omegaconf import DictConfig
-from savant.remote_file.schema import RemoteFile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import FrozenSet, Optional, Set, Type, Union
+from urllib.parse import urlparse
 
+from omegaconf import DictConfig
+
+from savant.remote_file.schema import RemoteFile
 
 __all__ = ['RemoteFileManagerType', 'RemoteFileHandler', 'RemoteFileError']
 

--- a/savant/remote_file/http.py
+++ b/savant/remote_file/http.py
@@ -1,9 +1,11 @@
 """HTTP file handler."""
-from typing import Optional
-from pathlib import Path
 import shutil
-from tqdm import tqdm
+from pathlib import Path
+from typing import Optional
+
 import requests
+from tqdm import tqdm
+
 from savant.remote_file.base import RemoteFileHandler
 
 __all__ = ['HTTPFileHandler']

--- a/savant/remote_file/s3.py
+++ b/savant/remote_file/s3.py
@@ -2,12 +2,13 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-from tqdm import tqdm
+
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
-from savant.remote_file.base import RemoteFileHandler, RemoteFileError
+from tqdm import tqdm
 
+from savant.remote_file.base import RemoteFileError, RemoteFileHandler
 
 __all__ = ['S3FileHandler']
 

--- a/savant/remote_file/schema.py
+++ b/savant/remote_file/schema.py
@@ -1,6 +1,7 @@
 """Remote file schema definition."""
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
+
 from omegaconf import MISSING
 
 

--- a/savant/remote_file/utils.py
+++ b/savant/remote_file/utils.py
@@ -1,10 +1,10 @@
 """Remote file utils."""
-from pathlib import Path
-from typing import List, Optional
 import hashlib
 import shutil
 import tarfile
 import zipfile
+from pathlib import Path
+from typing import List, Optional
 
 
 def get_file_checksum(file_path: Path) -> str:

--- a/savant/selector/detector.py
+++ b/savant/selector/detector.py
@@ -1,6 +1,7 @@
 """Detector's bbox selectors."""
-from numba import njit, uint8, uint16, float32
 import numpy as np
+from numba import float32, njit, uint8, uint16
+
 from savant.base.selector import BaseSelector
 
 

--- a/savant/utils/artist/artist_gpumat.py
+++ b/savant/utils/artist/artist_gpumat.py
@@ -1,10 +1,12 @@
 """Artist implementation using OpenCV GpuMat."""
-from typing import Tuple, Optional, Union, List
 from contextlib import AbstractContextManager
-import numpy as np
+from typing import List, Optional, Tuple, Union
+
 import cv2
-from savant_rs.primitives.geometry import BBox, RBBox
+import numpy as np
 from savant_rs.draw_spec import PaddingDraw
+from savant_rs.primitives.geometry import BBox, RBBox
+
 from .position import Position, get_bottom_left_point
 
 

--- a/savant/utils/artist/position.py
+++ b/savant/utils/artist/position.py
@@ -1,6 +1,6 @@
 """Anchor point position enum and utility."""
-from typing import Tuple
 from enum import Enum
+from typing import Tuple
 
 
 class Position(Enum):

--- a/savant/utils/draw_spec.py
+++ b/savant/utils/draw_spec.py
@@ -1,15 +1,9 @@
-from typing import Optional, Tuple
 import copy
-from savant_rs.draw_spec import (
-    BoundingBoxDraw,
-    ColorDraw,
-    LabelDraw,
-    DotDraw,
-    PaddingDraw,
-    ObjectDraw,
-    LabelPosition,
-    LabelPositionKind,
-)
+from typing import Optional, Tuple
+
+from savant_rs.draw_spec import (BoundingBoxDraw, ColorDraw, DotDraw,
+                                 LabelDraw, LabelPosition, LabelPositionKind,
+                                 ObjectDraw, PaddingDraw)
 
 
 def convert_hex_to_rgba(hex_color: str) -> Tuple[int, int, int, int]:

--- a/savant/utils/image.py
+++ b/savant/utils/image.py
@@ -1,5 +1,5 @@
 import math
-from typing import Union, Tuple, Optional
+from typing import Optional, Tuple, Union
 
 import cv2
 import numpy as np

--- a/savant/utils/logging.py
+++ b/savant/utils/logging.py
@@ -1,8 +1,8 @@
 """Logger utils."""
-from typing import Optional
 import logging
 import logging.config
 import os
+from typing import Optional
 
 
 def _get_default_loglevel() -> str:

--- a/savant/utils/sink_factories.py
+++ b/savant/utils/sink_factories.py
@@ -15,12 +15,8 @@ from savant.config.schema import PipelineElement
 from savant.gstreamer.codecs import CodecInfo
 from savant.gstreamer.metadata import SourceFrameMeta
 from savant.utils.registry import Registry
-from savant.utils.zeromq import (
-    Defaults,
-    SenderSocketTypes,
-    parse_zmq_socket_uri,
-    receive_response,
-)
+from savant.utils.zeromq import (Defaults, SenderSocketTypes,
+                                 parse_zmq_socket_uri, receive_response)
 
 logger = logging.getLogger(__name__)
 

--- a/savant/utils/source_info.py
+++ b/savant/utils/source_info.py
@@ -1,7 +1,8 @@
 """SourceInfo structure and SourceInfoRegistry singleton."""
-from typing import List, Optional, Dict
-from threading import Event
 from dataclasses import dataclass
+from threading import Event
+from typing import Dict, List, Optional
+
 from savant.gstreamer import Gst
 from savant.utils.singleton import SingletonMeta
 

--- a/savant/utils/version.py
+++ b/savant/utils/version.py
@@ -1,5 +1,6 @@
 """Parses VERSION file."""
 from pathlib import Path
+
 from savant.utils.singleton import SingletonMeta
 
 VERSION_FILE_PATH = Path(__file__).parent.parent / 'VERSION'

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,18 +1,18 @@
 """Common utilities for run scripts."""
-import string
-from pathlib import Path
-from typing import List, Iterable, Optional, Tuple
-import sys
 import os
 import pathlib
+import string
 import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
 
 import click
 
 sys.path.append(str(Path(__file__).parent.parent))
+from savant.utils.platform import is_aarch64
 from savant.utils.re_patterns import socket_uri_pattern
 from savant.utils.version import version
-from savant.utils.platform import is_aarch64
 
 # docker registry to use with scripts, set to "None" to use local images
 DOCKER_REGISTRY = 'ghcr.io/insight-platform'

--- a/scripts/run_module.py
+++ b/scripts/run_module.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Run module."""
-from typing import Optional
 import os
 import pathlib
+from typing import Optional
+
 import click
-from common import docker_image_option, get_tcp_parameters, get_ipc_mounts, run_command
+from common import (docker_image_option, get_ipc_mounts, get_tcp_parameters,
+                    run_command)
 
 
 def get_downloads_mount(

--- a/scripts/run_perf.py
+++ b/scripts/run_perf.py
@@ -14,11 +14,11 @@ docker run --rm \
  --endpoint-url=https://eu-central-1.linodeobjects.com \
  s3 sync s3://savant-data/demo /data
 """
-from pathlib import Path
-from typing import Generator
 import argparse
 import re
 import subprocess
+from pathlib import Path
+from typing import Generator
 
 
 def launch_script(script: Path) -> Generator[str, None, None]:

--- a/scripts/run_sink.py
+++ b/scripts/run_sink.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python3
 """Run sink adapter."""
 import os
-from typing import Optional
 import uuid
+from typing import Optional
 
 import click
-
-from common import (
-    adapter_docker_image_option,
-    build_common_envs,
-    build_docker_run_command,
-    fps_meter_options,
-    run_command,
-    source_id_option,
-    validate_source_id,
-)
+from common import (adapter_docker_image_option, build_common_envs,
+                    build_docker_run_command, fps_meter_options, run_command,
+                    source_id_option, validate_source_id)
 
 
 @click.group()

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -4,15 +4,9 @@ import os
 from typing import List, Optional
 
 import click
-
-from common import (
-    adapter_docker_image_option,
-    build_common_envs,
-    build_docker_run_command,
-    fps_meter_options,
-    run_command,
-    source_id_option,
-)
+from common import (adapter_docker_image_option, build_common_envs,
+                    build_docker_run_command, fps_meter_options, run_command,
+                    source_id_option)
 
 
 @click.group()


### PR DESCRIPTION
Lack of order in imports leads to duplicates and makes it harder to understand the code.

The issue only refereced two files but with the isort utility every python file has been modified automatically.