### PR TITLE
Fix pipeline shutdown on docker stop

### DIFF
--- a/adapters/ds/sinks/always_on_rtsp/__main__.py
+++ b/adapters/ds/sinks/always_on_rtsp/__main__.py
@@ -1,6 +1,7 @@
 """Entrypoint for Always-On-RTSP sink."""
 
 import os
+import signal
 from distutils.util import strtobool
 from pathlib import Path
 from subprocess import Popen, TimeoutExpired
@@ -49,6 +50,9 @@ class Config:
 
 
 def main():
+    # To gracefully shutdown the adapter on SIGTERM (raise KeyboardInterrupt)
+    signal.signal(signal.SIGTERM, signal.getsignal(signal.SIGINT))
+
     init_logging()
     config = Config()
 

--- a/savant/entrypoint/main.py
+++ b/savant/entrypoint/main.py
@@ -1,5 +1,6 @@
 """Module entrypoint function."""
 import os
+import signal
 from pathlib import Path
 from threading import Thread
 
@@ -18,6 +19,9 @@ def main(config_file_path: str):
 
     :param config_file_path: Module configuration file path.
     """
+
+    # To gracefully shutdown the adapter on SIGTERM (raise KeyboardInterrupt)
+    signal.signal(signal.SIGTERM, signal.getsignal(signal.SIGINT))
 
     status_filepath = os.environ.get('SAVANT_STATUS_FILEPATH')
     if status_filepath is not None:
@@ -73,6 +77,8 @@ def main(config_file_path: str):
             try:
                 for msg in pipeline.stream():
                     sink(msg, **dict(module_name=config.name))
+            except KeyboardInterrupt:
+                logger.info('Shutting down.')
             except Exception as exc:  # pylint: disable=broad-except
                 logger.error(exc, exc_info=True)
                 # TODO: Sometimes pipeline hangs when exit(1) or not exit at all is called.


### PR DESCRIPTION
Looks like python ignores SIGTERM. Added SIGINT handler for SIGTERM to raise KeyboardIterrupt on `docker stop`.

```
 INFO  insight::savant::main                                > Shutting down.
 INFO  insight::savant::gstreamer::runner                   > Setting pipeline status to PipelineStatus.STOPPING.
[NvMultiObjectTracker] De-initialized
 INFO  insight::savant::zeromq_src::zeromq_src+zeromqsrc0   > Returning <enum GST_FLOW_FLUSHING of type Gst.FlowReturn>
 INFO  insight::savant::utils::zeromq                       > Closing ZeroMQ socket
 INFO  insight::savant::utils::zeromq                       > Terminating ZeroMQ context.
 INFO  insight::savant::utils::zeromq                       > ZeroMQ context terminated
 INFO  insight::savant::gstreamer::runner                   > The pipeline is about to stop. Operation took 0:00:33.883003.
 INFO  insight::savant::face_reid                           > Processed 787 frames, 23.23 FPS.
 INFO  insight::savant::gstreamer::runner                   > Setting pipeline status to PipelineStatus.STOPPED.
```