### PR TITLE
[Fix] AttributeError when ingress_frame_filter is not defined.

### DIFF
--- a/savant/config/module_config.py
+++ b/savant/config/module_config.py
@@ -55,7 +55,8 @@ def source_element_configurator(
     """Additional configuration steps for SourceElements."""
     # if dev mode is enabled in the module parameters
     # set dev mode for the ingress filter function
-    if module_config.parameters.dev_mode:
+    if (element_config.ingress_frame_filter is not None
+        and module_config.parameters.dev_mode):
         logger.debug(
             'Setting dev mode for ingress filter of SourceElement named "%s" to True.',
             element_config.name,


### PR DESCRIPTION
Check whether ingress_frame_filter is defined before setting dev_mode attribute.

```bash
 INFO  insight::savant::config::module_config > Configuring module "template"...
 INFO  insight::savant::config::module_config > Getting schema/configurator for zeromq_source_bin
Aliases for entries in sys.path:
    <distpkg>: /usr/local/lib/python3.8/dist-packages
Traceback (most recent call last):
    <distpkg> /savant/config/module_config.py:309  configure_element            element_config = configurator(element_config, module_config)
    <distpkg> /savant/config/module_config.py:63   source_element_configurator  element_config.ingress_frame_filter.dev_mode = True
AttributeError: 'NoneType' object has no attribute 'dev_mode'

The above exception was the direct cause of the following exception:

Aliases for entries in sys.path:
    <distpkg>: /usr/local/lib/python3.8/dist-packages
    <pwd>    : /opt/savant/src
Traceback (most recent call last):
    <pwd> /module/run.py:7                         <module>            main(os.path.join(os.path.dirname(__file__), 'module.yml'))
    <distpkg> /savant/entrypoint/main.py:46        main                config = ModuleConfig().load(module_config)
    <distpkg> /savant/config/module_config.py:475  load                configure_pipeline(module_cfg)
    <distpkg> /savant/config/module_config.py:351  configure_pipeline  module_cfg.pipeline.source = configure_element(
    <distpkg> /savant/config/module_config.py:314  configure_element   raise ModuleConfigException(
ModuleConfigException: Element zeromq_source_bin:v1: 'NoneType' object has no attribute 'dev_mode'
```