### PR TITLE
Fix playback issue for display sink

### DIFF
--- a/adapters/ds/gst_plugins/python/savant_rs_video_player.py
+++ b/adapters/ds/gst_plugins/python/savant_rs_video_player.py
@@ -219,7 +219,7 @@ class SavantRsVideoPlayer(LoggerMixin, Gst.Bin):
         )
 
         self.logger.debug('Set state of %s to READY', branch.sink.get_name())
-        branch.sink.set_state(Gst.State.READY)
+        branch.sink.set_state(Gst.State.PLAYING)
         self.logger.debug('Sync state of %s with parent', branch.sink.get_name())
         branch.sink.sync_state_with_parent()
 


### PR DESCRIPTION
## Compose

```
  rtsp-streams:
    image: ghcr.io/insight-platform/savant-adapters-gstreamer-l4t@sha256:1ae69f8cc3fc8599a24afa6dfab4d215886efe3e38bc3b41abcc6958230ed1d0
    restart: unless-stopped
    volumes:
      - /tmp/zmq_sockets:/tmp/zmq-sockets
    environment:
      - RTSP_URI=rtsp://hello.savant.video:8554/city-traffic
      - ZMQ_ENDPOINT=dealer+bind:ipc:///tmp/zmq-sockets/input-video.ipc
      - SOURCE_ID=output
      - SYNC_OUTPUT=False
    entrypoint: /opt/savant/adapters/gst/sources/rtsp.sh

  display-sink:
    image: ghcr.io/insight-platform/savant-adapters-deepstream-l4t@sha256:9c175b44d0170cbe9c8131609e25f42374eeac9fc6f5ff87e39598816b03b8a7
    restart: unless-stopped
    volumes:
      - /tmp/zmq_sockets:/tmp/zmq-sockets
      - /tmp/.X11-unix:/tmp/.X11-unix
      - /tmp/.docker.xauth:/tmp/.docker.xauth:rw
    environment:
      - ZMQ_ENDPOINT=router+connect:ipc:///tmp/zmq-sockets/input-video.ipc
      - SOURCE_ID=output
      - XAUTHORITY=/tmp/.docker.xauth
      - SYNC_OUTPUT=True
      - DISPLAY
    entrypoint: /opt/savant/adapters/ds/sinks/display.sh
    runtime: nvidia
```
## Issue
The output display gets stuck in a blank screen and no error in logs:
```
INFO  insight::savant::savant_rs_video_decode_bin > Adding branch with source opencv-out
 INFO  insight::savant::savant_rs_video_decode_bin > Branch with source opencv-out added
 INFO  insight::savant::savant_rs_video_demux      > Created new src pad for source opencv-out: src_opencv-out.
 INFO  insight::savant::savant_rs_video_player     > Added pad src_opencv-out on element savant_rs_video_decode_bin+savantrsvideodecodebin0
 INFO  insight::savant::savant_rs_video_player     > Adding branch with source opencv-out
 INFO  insight::savant::savant_rs_video_player     > Branch with source opencv-out added
 INFO  insight::savant::savant_rs_video_player     > Caps on pad src_opencv-out changed to video/x-raw, format=(string)RGBA, width=(int)768, height=(int)576, framerate=(fraction)30/1
```

## Fix
Setting state from READY to PLAYING fixes the issue:
https://github.com/insight-platform/Savant/blob/1bcd1fc4597360ad93d9032b0d695d867b0fa27d/adapters/ds/gst_plugins/python/savant_rs_video_player.py#L222

## Configuration
**Device**: Jetson Xavier NX
**Adapter docker**: ghcr.io/insight-platform/savant-adapters-deepstream-l4t@sha256:9c175b44d0170cbe9c8131609e25f42374eeac9fc6f5ff87e39598816b03b8a7
