### PR TITLE
raw-rgba to jpeg because in JP60 hardware jpeg is ok + 704

### DIFF
--- a/docs/source/savant_101/10_adapters.rst
+++ b/docs/source/savant_101/10_adapters.rst
@@ -734,7 +734,6 @@ The video file sink adapter extends the JSON metadata adapter by writing video f
 
 - ``DIR_LOCATION``: a location to write files to; can be a regular path or a path template; supported substitution parameters are ``%source_id`` and ``%src_filename``;
 - ``CHUNK_SIZE``: a chunk size in a number of frames; the stream is split into chunks and is written to separate folders with consecutive numbering; default is ``10000``; A value of ``0`` disables limit for number of frames in a chunk: the stream will be split into chunks only by EOS messages;
-- ``SKIP_FRAMES_WITHOUT_OBJECTS``: a flag indicating whether frames without objects are ignored in output; the default value is ``False``;
 - ``SOURCE_ID``: an optional filter to filter out frames with a specific ``source_id`` only;
 - ``SOURCE_ID_PREFIX`` an optional filter to filter out frames with a matching ``source_id`` prefix only.
 

--- a/samples/age_gender_recognition/docker-compose.l4t.yml
+++ b/samples/age_gender_recognition/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/area_object_counting/docker-compose.l4t.yml
+++ b/samples/area_object_counting/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
       - MODULE_NAME=area_object_counting
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/conditional_video_processing/docker-compose.l4t.yml
+++ b/samples/conditional_video_processing/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     depends_on:
       etcd:
         condition: service_healthy

--- a/samples/face_reid/docker-compose.l4t.yml
+++ b/samples/face_reid/docker-compose.l4t.yml
@@ -73,7 +73,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
     profiles:
       - demo

--- a/samples/intersection_traffic_meter/docker-compose.l4t.yml
+++ b/samples/intersection_traffic_meter/docker-compose.l4t.yml
@@ -33,7 +33,7 @@ services:
       - ZMQ_SRC_ENDPOINT=router+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/kafka_redis_adapter/docker-compose-no-keydb.l4t.yml
+++ b/samples/kafka_redis_adapter/docker-compose-no-keydb.l4t.yml
@@ -95,7 +95,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/kafka_redis_adapter/docker-compose.l4t.yml
+++ b/samples/kafka_redis_adapter/docker-compose.l4t.yml
@@ -108,7 +108,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/keypoint_detection/docker-compose.l4t.yml
+++ b/samples/keypoint_detection/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=router+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/license_plate_recognition/docker-compose.l4t.yml
+++ b/samples/license_plate_recognition/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=router+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/multiple_rtsp/docker-compose.l4t.yml
+++ b/samples/multiple_rtsp/docker-compose.l4t.yml
@@ -43,7 +43,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/nvidia_car_classification/docker-compose.l4t.yml
+++ b/samples/nvidia_car_classification/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/opencv_cuda_bg_remover_mog2/docker-compose.l4t.yml
+++ b/samples/opencv_cuda_bg_remover_mog2/docker-compose.l4t.yml
@@ -29,7 +29,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/panoptic_driving_perception/docker-compose.l4t.yml
+++ b/samples/panoptic_driving_perception/docker-compose.l4t.yml
@@ -31,7 +31,7 @@ services:
       - DOWNLOAD_PATH=/cache/downloads/panoptic_driving_perception
       - ZMQ_SRC_ENDPOINT=router+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/pass_through_processing/docker-compose.l4t.yml
+++ b/samples/pass_through_processing/docker-compose.l4t.yml
@@ -78,7 +78,7 @@ services:
       - METRICS_PROVIDER_PARAMS={"port":8000, "labels":{"module_stage":"draw-func"}}
       # Use default draw_func (savant.deepstream.drawfunc.NvDsDrawFunc)
       - DRAW_FUNC={}
-      - CODEC=raw-rgba
+      - CODEC=jpeg
       - MODEL_PATH=/cache/models/peoplenet_detector
       - DOWNLOAD_PATH=/cache/downloads/peoplenet_detector
       - ZMQ_SRC_ENDPOINT=sub+connect:ipc:///tmp/zmq-sockets/tracker-output.ipc

--- a/samples/peoplenet_detector/docker-compose.l4t.yml
+++ b/samples/peoplenet_detector/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/telemetry/docker-compose.l4t.yml
+++ b/samples/telemetry/docker-compose.l4t.yml
@@ -33,7 +33,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/traffic_meter/docker-compose.l4t.yml
+++ b/samples/traffic_meter/docker-compose.l4t.yml
@@ -35,7 +35,7 @@ services:
       - METRICS_FRAME_PERIOD=1000
       - DETECTOR=${DETECTOR}
       - MODULE_NAME=traffic_meter-${DETECTOR}
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:

--- a/samples/yolov8_seg/docker-compose.l4t.yml
+++ b/samples/yolov8_seg/docker-compose.l4t.yml
@@ -32,7 +32,7 @@ services:
       - ZMQ_SRC_ENDPOINT=sub+bind:ipc:///tmp/zmq-sockets/input-video.ipc
       - ZMQ_SINK_ENDPOINT=pub+bind:ipc:///tmp/zmq-sockets/output-video.ipc
       - METRICS_FRAME_PERIOD=1000
-      - CODEC=raw-rgba
+      - CODEC=jpeg
     runtime: nvidia
 
   always-on-sink:


### PR DESCRIPTION
The raw-rgba format is inefficient from the memory transfer perspective. 