### PR TITLE
Fix batched_push_timeout documentation

### DIFF
--- a/docs/source/advanced_topics/0_batching.rst
+++ b/docs/source/advanced_topics/0_batching.rst
@@ -23,7 +23,7 @@ The pipeline configuration file defines parameters regulating the batch size. Th
 
 The ``batch_size`` parameter is configured for video multiplexing. When it is **not** configured, it is set based on the value defined for the first pipeline model. The default value is ``1``.
 
-The ``batched_push_timeout`` defines the maximum time the pipeline waits for the batch to be fully formed, pushing out partially formed batches if the wait time exceeds this threshold. The smaller value decreases latency, while the larger one results in greater throughput. The default value is: ``4000000`` (``4`` seconds).
+The ``batched_push_timeout`` defines the maximum time the pipeline waits for the batch to be fully formed, pushing out partially formed batches if the wait time exceeds this threshold. The smaller value decreases latency, while the larger one results in greater throughput. The default value is: ``2000`` (``2`` milliseconds).
 
 .. tip::
 


### PR DESCRIPTION
The documentation is showing the wrong default value for the parameter `batched_push_timeout`. 

The [documentation](https://github.com/insight-platform/Savant/blob/864920d79621d901cc23af0a5d1838139d631564/docs/source/advanced_topics/0_batching.rst#L26) indicates the default value is `4000000` (`4` seconds), but the [source code](https://github.com/insight-platform/Savant/blob/864920d79621d901cc23af0a5d1838139d631564/savant/deepstream/pipeline.py#L104) has the value `2000`, which matches what I see in the logs when I don't inform the parameter: 
`Pipeline frame processing parameters: { ... 'batched-push-timeout': 2000 ... }`

I'm assuming the code is correct and the documentation has to be updated.