### PR TITLE
Specify versions of building packages

### DIFF
--- a/docker/Dockerfile.adapters-gstreamer
+++ b/docker/Dockerfile.adapters-gstreamer
@@ -33,12 +33,12 @@ RUN apt-get update \
 
 # install/upgrade pip and builders
 RUN python3 -m pip install --no-cache-dir --upgrade \
-    build \
-    ninja \
-    pip \
-    scikit-build \
-    setuptools \
-    wheel
+        'build~=1.2.1' \
+        'ninja~=1.11.1.1' \
+        'pip~=24.2' \
+        'scikit-build~=0.18.1' \
+        'setuptools~=73.0.1' \
+        'wheel~=0.44.0'
 
 # install cmake
 ARG TARGETARCH


### PR DESCRIPTION
Can't build aravis with setuptools 74.0.0 https://github.com/insight-platform/Savant/actions/runs/10592465756/job/29362739923