### PR TITLE
Fixed original_resolution_processing README.md

### DIFF
--- a/samples/original_resolution_processing/README.md
+++ b/samples/original_resolution_processing/README.md
@@ -25,7 +25,7 @@ The demo uses models that are compiled into TensorRT engines the first time the 
 ```bash
 # you are expected to be in Savant/ directory
 
-./scripts/run_module.py --build-engines samples/peoplenet_detector/module.yml
+./scripts/run_module.py --build-engines samples/original_resolution_processing/module.yml
 ```
 
 ## Run Demo
@@ -34,13 +34,13 @@ The demo uses models that are compiled into TensorRT engines the first time the 
 # you are expected to be in Savant/ directory
 
 # if x86
-docker compose -f samples/different_resolutions/docker-compose.x86.yml up
+docker compose -f samples/original_resolution_processing/docker-compose.x86.yml up
 
 # if Jetson
-docker compose -f samples/different_resolutions/docker-compose.l4t.yml up
+docker compose -f samples/original_resolution_processing/docker-compose.l4t.yml up
 
 # open 'rtsp://127.0.0.1:554/stream/video-720p' and 'rtsp://127.0.0.1:554/stream/video-1080p' in your player
-# or visit 'http://127.0.0.1:888/stream/video-720p/' and 'http://127.0.0.1:888/stream/video-720p/' (LL-HLS)
+# or visit 'http://127.0.0.1:888/stream/video-720p/' and 'http://127.0.0.1:888/stream/video-1080p/' (LL-HLS)
 
 # Ctrl+C to stop running the compose bundle
 ```


### PR DESCRIPTION
This pull request includes updates to the `samples/original_resolution_processing/README.md` file to correct paths and URLs for running the demo. The key changes ensure that the instructions are accurate and point to the correct resources.

Updates to demo instructions:

* Modified the command to build TensorRT engines to use the correct module file (`samples/original_resolution_processing/module.yml`).
* Updated the Docker Compose commands to use the correct file paths for both x86 and Jetson platforms (`samples/original_resolution_processing/docker-compose.x86.yml` and `samples/original_resolution_processing/docker-compose.l4t.yml`).
* Corrected the URLs for accessing video streams to ensure the 1080p stream URL is accurate (`http://127.0.0.1:888/stream/video-1080p/`).