### PR TITLE
Increase buffer size for image header parsing to 512 KB for better image dimensions detection

### DIFF
--- a/savant/client/image_source/img_header_parse.py
+++ b/savant/client/image_source/img_header_parse.py
@@ -16,7 +16,8 @@ def get_image_size_codec(file: Union[str, PathLike, BinaryIO]) -> Tuple[int, int
     :return: Image width, height and codec.
     """
     if hasattr(file, 'read') and hasattr(file, 'seek'):
-        magic_out = magic.from_buffer(file.read(2048))
+        # read only the first 512 KB of the file hoping that the SOF header segment is there
+        magic_out = magic.from_buffer(file.read(512*1024))
         file.seek(0)
     elif isinstance(file, (str, PathLike)):
         magic_out = magic.from_file(file)


### PR DESCRIPTION
Closes #969

Increase buffer size for image header parsing to 512 KB for better image dimensions detection