### PR TITLE
Custom absolute timestamp offset

### DIFF
--- a/adapters/gst/sources/ffmpeg.sh
+++ b/adapters/gst/sources/ffmpeg.sh
@@ -50,7 +50,7 @@ PIPELINE=(
     savant_parse_bin !
 )
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     PIPELINE+=(
         shift_timestamps offset="${TS_OFFSET}" !
     )

--- a/adapters/gst/sources/gige_cam.sh
+++ b/adapters/gst/sources/gige_cam.sh
@@ -80,7 +80,7 @@ if [[ "${ENCODE,,}" == "true" ]]; then
     )
 fi
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     if [[ "${ENCODE,,}" == "true" ]]; then
         # x265enc adds offset to timestamps to avoid negative timestamps
         TS_OFFSET="$((TS_OFFSET - 3600000000000000))"

--- a/adapters/gst/sources/media_files.sh
+++ b/adapters/gst/sources/media_files.sh
@@ -61,7 +61,7 @@ PIPELINE=(
     adjust_timestamps !
 )
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     PIPELINE+=(
         shift_timestamps offset="${TS_OFFSET}" !
     )

--- a/adapters/gst/sources/multi_stream.sh
+++ b/adapters/gst/sources/multi_stream.sh
@@ -72,7 +72,7 @@ PIPELINE+=(
     adjust_timestamps !
 )
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     PIPELINE+=(
         shift_timestamps offset="${TS_OFFSET}" !
     )

--- a/adapters/gst/sources/rtsp.sh
+++ b/adapters/gst/sources/rtsp.sh
@@ -54,7 +54,7 @@ PIPELINE=(
     savant_parse_bin !
 )
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     PIPELINE+=(
         shift_timestamps offset="${TS_OFFSET}" !
     )

--- a/adapters/gst/sources/video_loop.sh
+++ b/adapters/gst/sources/video_loop.sh
@@ -41,7 +41,7 @@ PIPELINE=(
     adjust_timestamps !
 )
 if [[ "${USE_ABSOLUTE_TIMESTAMPS,,}" == "true" ]]; then
-    TS_OFFSET="$(date +%s%N)"
+    TS_OFFSET="${ABSOLUTE_TIMESTAMPS_OFFSET:-$(date +%s%N)}"
     PIPELINE+=(
         shift_timestamps offset="${TS_OFFSET}" !
     )

--- a/docs/source/savant_101/10_adapters.rst
+++ b/docs/source/savant_101/10_adapters.rst
@@ -237,10 +237,11 @@ Most source adapters accept the following common parameters:
 
 - ``SOURCE_ID``: a string identifier for a stream processed; this option is **required**; every stream must have a unique identifier, if identifiers collide, processing may cause unpredictable results; the identifier may encode user-defined semantics in a prefix, like ``rtsp.stream.1``; many sink adapters can filter out streams by prefix or full ``SOURCE_ID``;
 - ``ZMQ_ENDPOINT``: adapter's socket where it sends media stream; it must form a valid ZeroMQ pair with module's input socket; the endpoint coding scheme is ``[<socket_type>+(bind|connect):]<endpoint>``;
-- ``FPS_PERIOD_FRAMES``; a number of frames between FPS reports; FPS reporting helps to estimate the performance of the pipeline components deployed; default is ``1000``;
-- ``FPS_PERIOD_SECONDS``; a number of seconds between FPS reports; default is ``None`` which means that FPS reporting uses ``FPS_PERIOD_FRAMES``;
-- ``FPS_OUTPUT``; a path to the file for FPS reports; default is ``stdout``;
-- ``USE_ABSOLUTE_TIMESTAMPS``; when ``True`` the adapter puts absolute timestamps into the frames, i.e. the timestamps of the frames start from the time of adapter launch; default is ``False``.
+- ``FPS_PERIOD_FRAMES``: a number of frames between FPS reports; FPS reporting helps to estimate the performance of the pipeline components deployed; default is ``1000``;
+- ``FPS_PERIOD_SECONDS``: a number of seconds between FPS reports; default is ``None`` which means that FPS reporting uses ``FPS_PERIOD_FRAMES``;
+- ``FPS_OUTPUT``: a path to the file for FPS reports; default is ``stdout``;
+- ``USE_ABSOLUTE_TIMESTAMPS``: when ``True`` the adapter puts absolute timestamps into the frames, i.e. the timestamps of the frames start from the time of adapter launch; default is ``False``;
+- ``ABSOLUTE_TIMESTAMPS_OFFSET``: defines the timestamp offset when ``USE_ABSOLUTE_TIMESTAMPS`` is active; default is the time of adapter launch.
 
 .. _image_file_source_adapter:
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -156,6 +156,7 @@ def build_common_envs(
     fps_output: Optional[str],
     zmq_endpoint: str,
     use_absolute_timestamps: Optional[bool] = None,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Generate env var run options."""
     envs = build_zmq_endpoint_envs(
@@ -165,6 +166,8 @@ def build_common_envs(
         envs.append(f'SOURCE_ID={source_id}')
     if use_absolute_timestamps is not None:
         envs.append(f'USE_ABSOLUTE_TIMESTAMPS={use_absolute_timestamps}')
+    if absolute_timestamps_offset is not None:
+        envs.append(f'ABSOLUTE_TIMESTAMPS_OFFSET={absolute_timestamps_offset}')
     envs += build_fps_meter_envs(
         fps_period_frames=fps_period_frames,
         fps_period_seconds=fps_period_seconds,

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -72,6 +72,7 @@ def files_source(
     entrypoint: str = '/opt/savant/adapters/gst/sources/media_files.sh',
     extra_volumes: List[str] = None,
     detach: bool = False,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read image or video files from LOCATION.
     LOCATION can be single file, directory or HTTP URL.
@@ -97,6 +98,7 @@ def files_source(
             fps_output=fps_output,
             zmq_endpoint=out_endpoint,
             use_absolute_timestamps=use_absolute_timestamps,
+            absolute_timestamps_offset=absolute_timestamps_offset,
         )
         + [f'LOCATION={location}', f'FILE_TYPE={file_type}']
         + envs
@@ -159,6 +161,7 @@ def videos_source(
     read_metadata: bool,
     eos_on_file_end: bool,
     eos_on_frame_params_change: bool,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read video files from LOCATION.
     LOCATION can be single file, directory or HTTP URL.
@@ -180,6 +183,7 @@ def videos_source(
             f'EOS_ON_FRAME_PARAMS_CHANGE={eos_on_frame_params_change}',
         ],
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     )
 
 
@@ -241,6 +245,7 @@ def video_loop_source(
     loss_rate: float,
     location: str,
     read_metadata: bool,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read a video file from LOCATION and loop it.
     LOCATION can be single file, directory or HTTP URL.
@@ -275,6 +280,7 @@ def video_loop_source(
         entrypoint='/opt/savant/adapters/gst/sources/video_loop.sh',
         extra_volumes=volumes,
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     )
 
 
@@ -341,6 +347,7 @@ def multi_stream_source(
     shutdown_auth: Optional[str],
     location: str,
     read_metadata: bool,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read a video file from LOCATION and sends it to with multiple source IDs.
     LOCATION can be single file or HTTP URL.
@@ -379,6 +386,7 @@ def multi_stream_source(
         entrypoint='/opt/savant/adapters/gst/sources/multi_stream.sh',
         extra_volumes=volumes,
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     )
 
 
@@ -434,6 +442,7 @@ def images_source(
     read_metadata: bool,
     eos_on_file_end: bool,
     eos_on_frame_params_change: bool,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read image files from LOCATION.
     LOCATION can be single file, directory or HTTP URL.
@@ -457,6 +466,7 @@ def images_source(
             f'EOS_ON_FRAME_PARAMS_CHANGE={eos_on_frame_params_change}',
         ],
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     )
 
 
@@ -513,6 +523,7 @@ def rtsp_source(
     fps_period_seconds: Optional[float],
     fps_output: str,
     rtsp_uri: str,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read video stream from RTSP_URI."""
 
@@ -523,6 +534,7 @@ def rtsp_source(
         fps_output=fps_output,
         zmq_endpoint=out_endpoint,
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     ) + [
         f'RTSP_URI={rtsp_uri}',
         f'RTSP_TRANSPORT={rtsp_transport}',
@@ -632,6 +644,7 @@ def gige_cam_source(
     encode_speed_preset: str,
     encode_tune: str,
     camera_name: Optional[str],
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read video stream from GigE camera CAMERA_NAME.
 
@@ -657,6 +670,7 @@ def gige_cam_source(
         fps_output=fps_output,
         zmq_endpoint=out_endpoint,
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     )
 
     envs_dict = {
@@ -754,6 +768,7 @@ def ffmpeg_source(
     fps_period_seconds: Optional[float],
     fps_output: str,
     uri: str,
+    absolute_timestamps_offset: Optional[int] = None,
 ):
     """Read video stream from URI using FFmpeg library."""
 
@@ -764,6 +779,7 @@ def ffmpeg_source(
         fps_output=fps_output,
         zmq_endpoint=out_endpoint,
         use_absolute_timestamps=use_absolute_timestamps,
+        absolute_timestamps_offset=absolute_timestamps_offset,
     ) + [
         f'URI={uri}',
         f'BUFFER_LEN={buffer_len}',


### PR DESCRIPTION
Hi, we have a system that requires absolute timestamps, but they should start from a predefined time (actual video time) and not the time the adapter launched.

By default, adapters will use the current time when `USE_ABSOLUTE_TIMESTAMPS` is enabled. Now, I added the parameter `ABSOLUTE_TIMESTAMPS_OFFSET` that allows us to define a custom value.

Is this something you're willing to merge? Please feel free to suggest any changes, add commits, or completely rewrite the PR.

