### PR TITLE
Update nvinfer config parser

### DIFF
--- a/savant/deepstream/nvinfer/file_config.py
+++ b/savant/deepstream/nvinfer/file_config.py
@@ -292,14 +292,21 @@ class NvInferConfig:
         config['class-attrs-all'] = {'pre-cluster-threshold': 1e10}
         # replace class-attrs parameters with selector kwargs
         for obj in model_config.output.objects:
+            key = f'class-attrs-{obj.class_id}'
             class_attrs = {}
             if not obj.selector or 'kwargs' not in obj.selector:
                 obj.selector = NVINFER_DEFAULT_OBJECT_SELECTOR
             for field in NvInferConfig._CLASS_ATTR_MAP:
+                if key in config:
+                    # use existing config value as default
+                    value = config[key].get(field.property_name)
+                    if value is not None:
+                        class_attrs[field.property_name] = value
+                        continue
                 value = obj.selector.kwargs.get(field.name)
                 if value is not None:
                     class_attrs[field.property_name] = value
             if class_attrs:
-                config[f'class-attrs-{obj.class_id}'] = class_attrs
+                config[key] = class_attrs
 
         return config


### PR DESCRIPTION
This PR enables one to overwrite class-level confidence and nms thresholds with the values coming from a [config file](https://docs.savant-ai.io/v0.5.14/reference/api/generated/savant.deepstream.nvinfer.model.NvInferAttributeModel.html#savant.deepstream.nvinfer.model.NvInferAttributeModel.config_file). In this way, one could use a single `module.yml` file with different GPUs, where each GPU has its own confidence and nms thresholds. If `pre-cluster-threshold` or `nms-iou-threshold` values are missing for a class in the config file, then the default values defined in the following lines are used for these classes, as it was before
https://github.com/insight-platform/Savant/blob/2f69b148e07157e8c4273df910e816c37d0f55aa/savant/deepstream/nvinfer/file_config.py#L211-L212