### PR TITLE
Documentation links update

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ questions you may have.
 ## Quick Links
 
 - [Blog](https://b.savant-ai.io/)
-- [Getting Started Tutorial](https://docs.savant-ai.io/develop/getting_started/2_module_devguide.html)
+- [Getting Started Tutorial](https://savant-ai.io/docs/develop/getting_started/2_module_devguide.html)
 - [Pipeline Samples](https://github.com/insight-platform/Savant/tree/develop/samples)
-- [Documentation](https://docs.savant-ai.io/)
+- [Documentation](https://savant-ai.io/docs/)
 - [Performance Regression Tracking Dashboard](docs/performance.md)
 
 ## Getting Started
 
 First, take a look at the runtime
-configuration [guide](https://docs.savant-ai.io/develop/getting_started/0_configure_prod_env.html) to configure the
+configuration [guide](https://savant-ai.io/docs/develop/getting_started/0_configure_prod_env.html) to configure the
 working environment.
 
 The [demo](https://github.com/insight-platform/Savant/tree/develop/samples/peoplenet_detector) shows a pipeline
@@ -219,31 +219,31 @@ as is" or modify for your needs.
 
 The following source adapters are available:
 
-- [Local video file](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Local directory of video files](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Video URL](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Local image file](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [Local directory of image files](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [Image URL](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [RTSP stream (FFmpeg)](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#ffmpeg-rtsp-source-adapter);
-- [Multi-stream RTSP (Retina)](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#retina-rtsp-source-adapter);
-- [USB/CSI camera](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#usb-cam-source-adapter);
-- [GigE (Genicam) industrial cam](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#gige-vision-source-adapter);
-- [Kafka-Redis](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#kafka-redis-source-adapter);
-- [Video loop URL](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#video-loop-source-adapter);
-- [Multi-stream Source](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#multi-stream-source-adapter);
-- [Amazon Kinesis Video Streams Source](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#kinesis-video-stream-source-adapter);
-- [Message Dump Player](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#message-dump-player-source-adapter).
+- [Local video file](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
+- [Local directory of video files](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
+- [Video URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
+- [Local image file](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
+- [Local directory of image files](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
+- [Image URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
+- [RTSP stream (FFmpeg)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#ffmpeg-rtsp-source-adapter);
+- [Multi-stream RTSP (Retina)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#retina-rtsp-source-adapter);
+- [USB/CSI camera](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#usb-cam-source-adapter);
+- [GigE (Genicam) industrial cam](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#gige-vision-source-adapter);
+- [Kafka-Redis](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kafka-redis-source-adapter);
+- [Video loop URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-loop-source-adapter);
+- [Multi-stream Source](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#multi-stream-source-adapter);
+- [Amazon Kinesis Video Streams Source](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kinesis-video-stream-source-adapter);
+- [Message Dump Player](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#message-dump-player-source-adapter).
 
 Several sink adapters are implemented:
 
-- [Inference results are placed into JSON file stream](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#json-metadata-sink-adapter);
-- [Resulting video overlay displayed on a screen (per source)](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#display-sink-adapter);
-- [MP4 file (per source)](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#video-file-sink-adapter);
-- [Image directory (per source)](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#image-file-sink-adapter);
-- [Always-On RTSP Stream Sink](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#always-on-rtsp-sink-adapter);
-- [Kafka-Redis](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#kafka-redis-sink-adapter);
-- [Amazon Kinesis Video Streams Sink](https://docs.savant-ai.io/develop/savant_101/10_adapters.html#multistream-kinesis-video-stream-sink-adapter).
+- [Inference results are placed into JSON file stream](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#json-metadata-sink-adapter);
+- [Resulting video overlay displayed on a screen (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#display-sink-adapter);
+- [MP4 file (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-sink-adapter);
+- [Image directory (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-sink-adapter);
+- [Always-On RTSP Stream Sink](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#always-on-rtsp-sink-adapter);
+- [Kafka-Redis](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kafka-redis-sink-adapter);
+- [Amazon Kinesis Video Streams Sink](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#multistream-kinesis-video-stream-sink-adapter).
 
 ### 🎯 Dynamic Parameters Ingestion
 
@@ -310,9 +310,9 @@ Savant provides the Router [service](https://insight-platform.github.io/savant-r
 
 ## What's Next
 
-- [Getting Started Tutorial](https://docs.savant-ai.io/develop/getting_started/2_module_devguide.html)
+- [Getting Started Tutorial](https://savant-ai.io/docs/develop/getting_started/2_module_devguide.html)
 - [Publications and Samples](https://github.com/insight-platform/Savant/tree/develop/samples)
-- [Documentation](https://docs.savant-ai.io/)
+- [Documentation](https://savant-ai.io/docs/)
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ questions you may have.
 ## Quick Links
 
 - [Blog](https://b.savant-ai.io/)
-- [Getting Started Tutorial](https://savant-ai.io/docs/develop/getting_started/2_module_devguide.html)
+- [Getting Started Tutorial](https://savant-ai.io/docs/latest/getting_started/2_module_devguide.html)
 - [Pipeline Samples](https://github.com/insight-platform/Savant/tree/develop/samples)
 - [Documentation](https://savant-ai.io/docs/)
 - [Performance Regression Tracking Dashboard](docs/performance.md)
@@ -76,7 +76,7 @@ questions you may have.
 ## Getting Started
 
 First, take a look at the runtime
-configuration [guide](https://savant-ai.io/docs/develop/getting_started/0_configure_prod_env.html) to configure the
+configuration [guide](https://savant-ai.io/docs/latest/getting_started/0_configure_prod_env.html) to configure the
 working environment.
 
 The [demo](https://github.com/insight-platform/Savant/tree/develop/samples/peoplenet_detector) shows a pipeline
@@ -219,31 +219,31 @@ as is" or modify for your needs.
 
 The following source adapters are available:
 
-- [Local video file](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Local directory of video files](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Video URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-source-adapter);
-- [Local image file](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [Local directory of image files](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [Image URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-source-adapter);
-- [RTSP stream (FFmpeg)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#ffmpeg-rtsp-source-adapter);
-- [Multi-stream RTSP (Retina)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#retina-rtsp-source-adapter);
-- [USB/CSI camera](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#usb-cam-source-adapter);
-- [GigE (Genicam) industrial cam](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#gige-vision-source-adapter);
-- [Kafka-Redis](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kafka-redis-source-adapter);
-- [Video loop URL](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-loop-source-adapter);
-- [Multi-stream Source](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#multi-stream-source-adapter);
-- [Amazon Kinesis Video Streams Source](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kinesis-video-stream-source-adapter);
-- [Message Dump Player](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#message-dump-player-source-adapter).
+- [Local video file](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#video-file-source-adapter);
+- [Local directory of video files](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#video-file-source-adapter);
+- [Video URL](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#video-file-source-adapter);
+- [Local image file](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#image-file-source-adapter);
+- [Local directory of image files](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#image-file-source-adapter);
+- [Image URL](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#image-file-source-adapter);
+- [RTSP stream (FFmpeg)](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#ffmpeg-rtsp-source-adapter);
+- [Multi-stream RTSP (Retina)](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#retina-rtsp-source-adapter);
+- [USB/CSI camera](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#usb-cam-source-adapter);
+- [GigE (Genicam) industrial cam](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#gige-vision-source-adapter);
+- [Kafka-Redis](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#kafka-redis-source-adapter);
+- [Video loop URL](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#video-loop-source-adapter);
+- [Multi-stream Source](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#multi-stream-source-adapter);
+- [Amazon Kinesis Video Streams Source](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#kinesis-video-stream-source-adapter);
+- [Message Dump Player](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#message-dump-player-source-adapter).
 
 Several sink adapters are implemented:
 
-- [Inference results are placed into JSON file stream](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#json-metadata-sink-adapter);
-- [Resulting video overlay displayed on a screen (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#display-sink-adapter);
-- [MP4 file (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#video-file-sink-adapter);
-- [Image directory (per source)](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#image-file-sink-adapter);
-- [Always-On RTSP Stream Sink](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#always-on-rtsp-sink-adapter);
-- [Kafka-Redis](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#kafka-redis-sink-adapter);
-- [Amazon Kinesis Video Streams Sink](https://savant-ai.io/docs/develop/savant_101/10_adapters.html#multistream-kinesis-video-stream-sink-adapter).
+- [Inference results are placed into JSON file stream](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#json-metadata-sink-adapter);
+- [Resulting video overlay displayed on a screen (per source)](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#display-sink-adapter);
+- [MP4 file (per source)](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#video-file-sink-adapter);
+- [Image directory (per source)](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#image-file-sink-adapter);
+- [Always-On RTSP Stream Sink](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#always-on-rtsp-sink-adapter);
+- [Kafka-Redis](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#kafka-redis-sink-adapter);
+- [Amazon Kinesis Video Streams Sink](https://savant-ai.io/docs/latest/savant_101/10_adapters.html#multistream-kinesis-video-stream-sink-adapter).
 
 ### 🎯 Dynamic Parameters Ingestion
 
@@ -310,7 +310,7 @@ Savant provides the Router [service](https://insight-platform.github.io/savant-r
 
 ## What's Next
 
-- [Getting Started Tutorial](https://savant-ai.io/docs/develop/getting_started/2_module_devguide.html)
+- [Getting Started Tutorial](https://savant-ai.io/docs/latest/getting_started/2_module_devguide.html)
 - [Publications and Samples](https://github.com/insight-platform/Savant/tree/develop/samples)
 - [Documentation](https://savant-ai.io/docs/)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 The root directory of the Savant documentation. The documentation is built with [Sphinx](https://www.sphinx-doc.org/en/master/). 
 
-Up-to-date documentation is available [here](https://docs.savant-ai.io/). 
+Up-to-date documentation is available [here](https://savant-ai.io/docs/). 

--- a/samples/key_value_api/README.md
+++ b/samples/key_value_api/README.md
@@ -25,7 +25,7 @@ The key-value store is accessible via REST API. Use the script to read from the 
 docker compose -f samples/key_value_api/docker-compose.x86.yml exec -it first python /scripts/get_frame_counter.py
 ```
 
-The documentation for the Key-Value API is available at the Savant documentation [website](https://docs.savant-ai.io/develop/advanced_topics/15_embedded_kvs.html).
+The documentation for the Key-Value API is available at the Savant documentation [website](https://savant-ai.io/docs/develop/advanced_topics/15_embedded_kvs.html).
 
 ## How to Access the Key-Value Subscription With REST API
 

--- a/samples/key_value_api/README.md
+++ b/samples/key_value_api/README.md
@@ -25,7 +25,7 @@ The key-value store is accessible via REST API. Use the script to read from the 
 docker compose -f samples/key_value_api/docker-compose.x86.yml exec -it first python /scripts/get_frame_counter.py
 ```
 
-The documentation for the Key-Value API is available at the Savant documentation [website](https://savant-ai.io/docs/develop/advanced_topics/15_embedded_kvs.html).
+The documentation for the Key-Value API is available at the Savant documentation [website](https://savant-ai.io/docs/latest/advanced_topics/15_embedded_kvs.html).
 
 ## How to Access the Key-Value Subscription With REST API
 

--- a/samples/source_adapter_with_json_metadata/README.md
+++ b/samples/source_adapter_with_json_metadata/README.md
@@ -71,7 +71,7 @@ You can use the convert_coco_to_savant.py script as a starting point to prepare
 your input metadata. This script reads data from the COCO dataset annotations, 
 selects only objects with "person" label, and converts it into an input data format 
 for the framework. A detailed description of the input JSON file format with metadata 
-for the adapter is described in the documentation ([link](https://savant-ai.io/docs/advanced_topics/9_input_json_metadata.html)). 
+for the adapter is described in the documentation ([link](https://savant-ai.io/docs/latest/advanced_topics/9_input_json_metadata.html)). 
 Install the pycocotools library before running it.
 
 ```bash

--- a/samples/source_adapter_with_json_metadata/README.md
+++ b/samples/source_adapter_with_json_metadata/README.md
@@ -71,7 +71,7 @@ You can use the convert_coco_to_savant.py script as a starting point to prepare
 your input metadata. This script reads data from the COCO dataset annotations, 
 selects only objects with "person" label, and converts it into an input data format 
 for the framework. A detailed description of the input JSON file format with metadata 
-for the adapter is described in the documentation ([link](https://docs.savant-ai.io/advanced_topics/9_input_json_metadata.html)). 
+for the adapter is described in the documentation ([link](https://savant-ai.io/docs/advanced_topics/9_input_json_metadata.html)). 
 Install the pycocotools library before running it.
 
 ```bash


### PR DESCRIPTION
Update documentation links from `docs.savant-ai.io` to `savant-ai.io/docs` to reflect the correct URL structure.

---
<p><a href="https://cursor.com/agents?id=bc-b64bb147-0fcc-4bd8-b965-57d426ab9a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b64bb147-0fcc-4bd8-b965-57d426ab9a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure documentation-only URL updates; no code or runtime behavior changes.
> 
> **Overview**
> Updates multiple README files to point documentation links from `docs.savant-ai.io` to the new `savant-ai.io/docs` (and `savant-ai.io/docs/latest`) structure, including top-level quick links and sample-specific doc references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95386fa7e86c484b422ca47456dba9ac28717d9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->