### PR TITLE
Docs sitemap file

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@ sphinx_rtd_theme~=2.0
 sphinxcontrib-youtube~=1.4
 sphinxcontrib-images~=0.9
 sphinxcontrib-httpdomain~=1.8
+sphinx-sitemap~=2.6
 python-magic~=0.4.27
 requests~=2.32.5

--- a/docs/source/_templates/robots.txt.tpl
+++ b/docs/source/_templates/robots.txt.tpl
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /docs/latest/
 Disallow: /docs/v
+
+Sitemap: {{ pages_url }}/latest/sitemap.xml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'repo_link',
     'sphinxcontrib.images',
     'sphinxcontrib.httpdomain',
+    'sphinx_sitemap',
 ]
 
 images_config = {
@@ -96,6 +97,16 @@ autodoc_mock_imports = [
     'torch',
     'pynvbufsurfacegenerator',
 ]
+
+# -- Sitemap configuration ---------------------------------------------------
+
+docs_url = os.getenv('DOCS_URL', 'https://savant-ai.io/docs').rstrip('/')
+if os.getenv('MODE') == 'develop':
+    html_baseurl = f'{docs_url}/latest/'
+else:
+    html_baseurl = f'{docs_url}/v{release}/'
+
+sitemap_url_scheme = '{link}'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Implement `sitemap.xml` for the documentation to improve search engine discoverability and indexing.

This PR adds the `sphinx-sitemap` extension, configures it in `conf.py` to generate sitemaps with correct base URLs (using `DOCS_URL` environment variable), and updates `robots.txt.tpl` to include a `Sitemap:` directive.

---
<p><a href="https://cursor.com/agents?id=bc-83ae5cb2-aa33-4730-861e-f578cc09e5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83ae5cb2-aa33-4730-861e-f578cc09e5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change affecting Sphinx build output; main risk is incorrect `html_baseurl`/env configuration causing broken sitemap links.
> 
> **Overview**
> Adds `sphinx-sitemap` to the docs build and enables the `sphinx_sitemap` extension in `docs/source/conf.py` to generate `sitemap.xml`.
> 
> Configures `html_baseurl` from `DOCS_URL` and `MODE` (develop uses `/latest/`, otherwise `/v{release}/`) so sitemap links match the deployed docs URL, and updates `robots.txt.tpl` to include a `Sitemap:` directive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4f55a33c7287a325ba7931e60ff681c11dff8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->