### PR TITLE
added convenience notes

### DIFF
--- a/samples/nvarguscamerasrc/src/module.yml
+++ b/samples/nvarguscamerasrc/src/module.yml
@@ -4,13 +4,19 @@ name: nvarguscamerasrc
 parameters:
   batch_size: 2
   output_frame:
-    codec: hevc
-    encoder_params:
+    codec: jpeg
+    #codec: hevc # if you are on NX/AGX
+    hevc_encoder_params:
       profile: Main
       bitrate: 8000000
+    jpeg_encoder_params:
+      quality: 95
   draw_func: null
 pipeline:
   source:
+    # use
+    # v4l2-ctl -d /dev/video0 --list-formats-ext
+    # to determine camera formats and max fps
     element: nvarguscamerasrc_bin
     properties:
       sources:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML sample configuration change only; it alters default output encoding but doesn’t touch runtime code paths or security-sensitive logic.
> 
> **Overview**
> Switches the `nvarguscamerasrc` sample module’s `output_frame` default codec from HEVC to JPEG, adding `jpeg_encoder_params` (quality) and keeping HEVC settings under `hevc_encoder_params` with a commented hint for NX/AGX.
> 
> Adds inline usage notes in the pipeline source config for using `v4l2-ctl` to discover camera formats and max FPS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c83c594fbba7096e219c36aaf12f74b393ffae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->