### PR TITLE
docs: document frame metadata access in output converters

### DIFF
--- a/docs/source/savant_101/30_dm.rst
+++ b/docs/source/savant_101/30_dm.rst
@@ -193,6 +193,54 @@ An example of the converter for YOLOv4 listed below. The YOLOv4 model has two ou
             )
 
 
+Accessing Frame Metadata In A Converter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default a converter sees only the model output tensors, the model definition,
+and the ROI it ran on. A converter can also optionally receive the **frame
+metadata**, which lets its post-processing depend on the context of the frame —
+for example, applying different thresholds per source, or adapting to objects and
+tags already present on the frame.
+
+To opt in, add a ``metadata`` parameter to the converter's ``__call__``:
+
+.. code-block:: python
+
+    from typing import Optional
+    from savant.deepstream.meta.frame import NvDsFrameMeta
+
+    class TensorToBBoxConverter(BaseObjectModelOutputConverter):
+        def __call__(
+            self,
+            *output_layers: np.ndarray,
+            model: ObjectModel,
+            roi: Tuple[float, float, float, float],
+            metadata: Optional[NvDsFrameMeta] = None,
+        ) -> np.ndarray:
+            source_id = metadata.source_id if metadata is not None else None
+            ...
+
+The argument is passed a :py:class:`~savant.deepstream.meta.frame.NvDsFrameMeta`
+wrapper for the frame, exposing ``source_id``, ``pts``, the underlying
+``video_frame``, the objects already on the frame, and its tags.
+
+.. note::
+
+    The ``metadata`` argument is **opt-in and backward compatible**. Savant
+    inspects the converter's ``__call__`` signature once (the result is cached per
+    converter class, so there is no per-frame overhead) and passes ``metadata``
+    only when the parameter is declared. Converters written for earlier versions of
+    Savant — including all the built-in ones — keep working unchanged. When
+    ``metadata`` is used, the output conversion is additionally wrapped in a
+    ``convert-output`` telemetry span nested under the frame span, so it remains
+    traceable.
+
+The `output_converter_metadata sample <https://github.com/insight-platform/Savant/tree/develop/samples/output_converter_metadata>`__
+demonstrates this by combining it with :doc:`/advanced_topics/4_etcd`: a YOLO
+output converter reads ``metadata.source_id`` and looks up per-source detection
+thresholds in Etcd, which can be changed live without restarting the pipeline.
+
+
 Object Filtering
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/savant_101/30_dm.rst
+++ b/docs/source/savant_101/30_dm.rst
@@ -196,7 +196,7 @@ An example of the converter for YOLOv4 listed below. The YOLOv4 model has two ou
 Accessing Frame Metadata In A Converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default a converter sees only the model output tensors, the model definition,
+By default, a converter sees only the model output tensors, the model definition,
 and the ROI it ran on. A converter can also optionally receive the **frame
 metadata**, which lets its post-processing depend on the context of the frame —
 for example, applying different thresholds per source, or adapting to objects and

--- a/docs/source/savant_101/30_dm.rst
+++ b/docs/source/savant_101/30_dm.rst
@@ -220,20 +220,24 @@ To opt in, add a ``metadata`` parameter to the converter's ``__call__``:
             source_id = metadata.source_id if metadata is not None else None
             ...
 
-The argument is passed a :py:class:`~savant.deepstream.meta.frame.NvDsFrameMeta`
-wrapper for the frame, exposing ``source_id``, ``pts``, the underlying
-``video_frame``, the objects already on the frame, and its tags.
+When available, ``metadata`` is a
+:py:class:`~savant.deepstream.meta.frame.NvDsFrameMeta` wrapper for the frame,
+exposing ``source_id``, ``pts``, the underlying ``video_frame``, the objects
+already on the frame, and its tags. It is optional at call time: even when the
+converter declares the parameter, the framework may still pass ``None`` (for
+example, when the frame's ``VideoFrame`` context is unavailable), so a converter
+that uses it should guard against ``None`` — as the snippet above does.
 
 .. note::
 
     The ``metadata`` argument is **opt-in and backward compatible**. Savant
-    inspects the converter's ``__call__`` signature once (the result is cached per
-    converter class, so there is no per-frame overhead) and passes ``metadata``
-    only when the parameter is declared. Converters written for earlier versions of
-    Savant — including all the built-in ones — keep working unchanged. When
-    ``metadata`` is used, the output conversion is additionally wrapped in a
-    ``convert-output`` telemetry span nested under the frame span, so it remains
-    traceable.
+    inspects the converter's ``__call__`` signature only once and caches the result
+    per converter class, so the signature is not re-inspected on every frame (the
+    per-frame cost is just a cached lookup). ``metadata`` is passed only when the
+    parameter is declared, so converters written for earlier versions of Savant —
+    including all the built-in ones — keep working unchanged. When ``metadata`` is
+    used, the output conversion is additionally wrapped in a ``convert-output``
+    telemetry span nested under the frame span, so it remains traceable.
 
 The `output_converter_metadata sample <https://github.com/insight-platform/Savant/tree/develop/samples/output_converter_metadata>`__
 demonstrates this by combining it with :doc:`/advanced_topics/4_etcd`: a YOLO


### PR DESCRIPTION
Documents the optional `metadata` argument for model output converters, added in #1172 ("Support metadata passing to converters").

## Change

`docs/source/savant_101/30_dm.rst` — adds an **"Accessing Frame Metadata In A Converter"** subsection to the detector-model chapter's Converter section, covering:

- How to opt in — declare a `metadata: Optional[NvDsFrameMeta] = None` parameter on the converter's `__call__` (with a code snippet).
- What it exposes — `source_id`, `pts`, the underlying `video_frame`, the frame's objects, and tags.
- That it is **opt-in and backward compatible**: Savant inspects the converter's `__call__` signature once (cached per converter class, no per-frame overhead) and passes `metadata` only when declared, so existing/built-in converters keep working unchanged. Also notes the nested `convert-output` telemetry span.
- A pointer to the `output_converter_metadata` sample and a cross-link to the Etcd dynamic-reconfiguration page.

## Notes

- The API reference (`reference/api/converter.rst`) is auto-generated from docstrings, which #1172 already updated, so no manual change is needed there — the `metadata` parameter flows through automatically.
- RST validated: section underlines are well-formed, the `:doc:` Etcd target resolves, and the `NvDsFrameMeta` cross-reference uses the fully-qualified `savant.deepstream.meta.frame` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbsaV4NhYriTyUqxuzKd8Q)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds **"Accessing Frame Metadata In A Converter"** under the detector-model **Converter** section in `30_dm.rst`, documenting the optional `metadata` argument on converter `__call__` (from #1172).
> 
> The new text explains how to opt in with `metadata: Optional[NvDsFrameMeta] = None`, what fields are available (`source_id`, `pts`, `video_frame`, objects, tags), and that callers must handle `None`. It also notes **opt-in / backward compatibility** (signature inspected once per class, cached), nested **`convert-output`** telemetry when metadata is used, and links to the **`output_converter_metadata`** sample plus the Etcd dynamic-reconfiguration doc for per-source thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9cf7b09f76bbc257b74a4204c3c2403a702eb09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->