### PR TITLE
fix: update simpleeval and click to patch known vulnerabilities

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ scipy~=1.10
 # yaml config
 omegaconf~=2.3
 # omegaconf arithmetic resolver
-simpleeval~=0.9.12
+simpleeval~=1.0.5
 # dynamic pyfunc reloading
 inotify-simple~=1.3.5
 
@@ -19,7 +19,7 @@ google-cloud-storage~=3.1.0
 tqdm~=4.64
 
 # ClientSDK JpegSource, PngSource
-click~=8.1.6
+click~=8.3.3
 python-magic~=0.4.27
 
 # pyds


### PR DESCRIPTION
`pip-audit` flagged two dependencies with known CVEs:

- `simpleeval ~=0.9.12` → `~=1.0.5` (PYSEC-2026-132)
- `click ~=8.1.6` → `~=8.3.3` (PYSEC-2026-2132)

Verified API compatibility:
- `simpleeval`: `simple_eval()` with named args works as before (used in `savant/config/calc_resolver.py`)
- `click`: imports and CLI scripts unaffected

No breaking changes expected — both are minor/patch version bumps.