### PR TITLE
fix: update rtdetr sample for Savant 0.6 / DeepStream 7.1

### DIFF
--- a/samples/rtdetr/README.md
+++ b/samples/rtdetr/README.md
@@ -4,6 +4,18 @@ The sample shows how RT-DETR model can be used in a Savant module.
 
 The detector model was prepared in the ONNX format using instructions from [DeepStream-Yolo repo](https://github.com/marcoslucianops/DeepStream-Yolo/blob/master/docs/RTDETR_PyTorch.md).
 
+ONNX export tested with the following dependencies:
+
+- DeepStream-Yolo commit 2894bab
+- RT-DETR commit 0d0a4f5
+- numpy              1.26.4
+- onnx               1.14.0
+- onnxruntime        1.15.1
+- onnxslim           0.1.96
+- torch              2.0.1+cu118
+- torchvision        0.15.2+cu118
+- transformers       4.30.2
+
 Weights used: `v0.1/rtdetr_r50vd_6x_coco_from_paddle.pth`  from the [RT-DETR releases](https://github.com/lyuwenyu/storage/releases).
 
 Tested on platforms:

--- a/samples/rtdetr/docker/Dockerfile.l4t
+++ b/samples/rtdetr/docker/Dockerfile.l4t
@@ -1,9 +1,9 @@
 # build nvinfer custom library for yolo models (create engine and parse bbox functions)
 # https://github.com/marcoslucianops/DeepStream-Yolo
-FROM nvcr.io/nvidia/deepstream:7.0-triton-multiarch AS builder
+FROM nvcr.io/nvidia/deepstream:7.1-triton-multiarch AS builder
 
-ENV CUDA_VER=12.2
-ARG DS_YOLO_VER=5af9da189d91fa8808695c488a417f9f1c920b77
+ENV CUDA_VER=12.6
+ARG DS_YOLO_VER=2894bab
 ARG DS_YOLO_PATH=/opt/yolo
 ARG NVDSINFER_PATH=/opt/nvidia/deepstream/deepstream/sources/libs/nvdsinfer
 

--- a/samples/rtdetr/docker/Dockerfile.x86
+++ b/samples/rtdetr/docker/Dockerfile.x86
@@ -3,7 +3,7 @@
 FROM nvcr.io/nvidia/deepstream:7.1-triton-multiarch AS builder
 
 ENV CUDA_VER=12.6
-ARG DS_YOLO_VER=master
+ARG DS_YOLO_VER=2894bab
 ARG DS_YOLO_PATH=/opt/yolo
 ARG NVDSINFER_PATH=/opt/nvidia/deepstream/deepstream/sources/libs/nvdsinfer
 

--- a/samples/rtdetr/docker/Dockerfile.x86
+++ b/samples/rtdetr/docker/Dockerfile.x86
@@ -1,9 +1,9 @@
 # build nvinfer custom library for yolo models (create engine and parse bbox functions)
 # https://github.com/marcoslucianops/DeepStream-Yolo
-FROM nvcr.io/nvidia/deepstream:7.0-triton-multiarch AS builder
+FROM nvcr.io/nvidia/deepstream:7.1-triton-multiarch AS builder
 
-ENV CUDA_VER=12.2
-ARG DS_YOLO_VER=5af9da189d91fa8808695c488a417f9f1c920b77
+ENV CUDA_VER=12.6
+ARG DS_YOLO_VER=master
 ARG DS_YOLO_PATH=/opt/yolo
 ARG NVDSINFER_PATH=/opt/nvidia/deepstream/deepstream/sources/libs/nvdsinfer
 

--- a/samples/rtdetr/module.yml
+++ b/samples/rtdetr/module.yml
@@ -10,7 +10,7 @@ parameters:
   batch_size: 1
 
   model_name: rtdetr_r50
-  model_ver: 5af9da1
+  model_ver: 2894bab
 
   model: ${parameters.model_name}_${parameters.model_ver}
 


### PR DESCRIPTION
Fixes #1112

- Update builder base image from DeepStream 7.0 to 7.1
- Update CUDA_VER from 12.2 to 12.6
- Update DeepStream-Yolo from 5af9da1 to 2894bab (TensorRT 10 support)

The old DeepStream-Yolo commit used deprecated TensorRT 8 APIs (IPluginV2DynamicExt) that no longer compile against TensorRT 10.x shipped with DeepStream 7.1.

Note: the RT-DETR ONNX model hosted on S3 (savant-data) was exported with the old DeepStream-Yolo output format. It needs to be re-exported using the export_rtdetr_pytorch.py script from DeepStream-Yolo master to match the new parser. Without re-export, detections are incorrect.