### PR TITLE
feat(lpr): add proxy vehicle ROI for per-type COCO vehicle labels

### DIFF
--- a/samples/license_plate_recognition/README.md
+++ b/samples/license_plate_recognition/README.md
@@ -1,6 +1,8 @@
 # License plate recognition 
 
-The app partially reproduces [deepstream_lpr_app](https://github.com/NVIDIA-AI-IOT/deepstream_lpr_app) in the Savant framework. The pipeline detects cars using the YoloV11 model and detects license plates using the NVidia LPD model. Cars and plates track using NVidia tracker the license plate is recognized using the NVidia OCR model. The results are displayed on the frames.
+The app partially reproduces [deepstream_lpr_app](https://github.com/NVIDIA-AI-IOT/deepstream_lpr_app) in the Savant framework. The pipeline detects vehicles using the YOLOv11 model and detects license plates using the Nvidia LPD model. Vehicles are tracked using the Nvidia tracker, and the license plates are recognized using the Nvidia OCR model. The results are displayed on the frames.
+
+The demo also shows how to use a **proxy ROI** to run a model on several object classes at once. The detector assigns its own label to each COCO vehicle type it predicts (`car`, `motorcycle`, `bus`, `truck`), so that downstream units can distinguish between the types. A model unit, however, operates on a single parent object class only. To run the LPD model on every vehicle type, the [`create_vehicle_roi.py`](create_vehicle_roi.py) PyFunc adds a proxy child object labeled `vehicle` to each detected vehicle; the proxy occupies the same area as its parent (trimmed to the frame) and is used as the input object for the LPD model. The proxy object is not listed in `draw_func.rendered_objects`, hence it is not displayed. The tracker is placed before the PyFunc, so that it only receives the vehicles themselves and not the proxies, which fully overlap them.
 
 Preview:
 

--- a/samples/license_plate_recognition/create_vehicle_roi.py
+++ b/samples/license_plate_recognition/create_vehicle_roi.py
@@ -1,0 +1,64 @@
+"""Adds a proxy "vehicle" ROI object to every detected vehicle.
+
+The detector assigns its own label to each COCO vehicle type (car, motorcycle,
+bus, truck), so that downstream units can distinguish between them. An nvinfer
+unit, however, can operate on a single parent object class only. To run the LPD
+model on every vehicle type, a proxy child object with a common label is added
+to each detected vehicle; the proxy occupies the same area as its parent
+(trimmed to the frame) and is used as the input object for the LPD model.
+"""
+
+from savant_rs.primitives.geometry import BBox
+
+from savant.deepstream.meta.frame import NvDsFrameMeta
+from savant.deepstream.pyfunc import NvDsPyFuncPlugin
+from savant.gstreamer import Gst  # noqa: F401
+from savant.meta.object import ObjectMeta
+from savant.parameter_storage import param_storage
+
+
+class CreateVehicleROI(NvDsPyFuncPlugin):
+    """PyFunc that creates a proxy ROI for every detected vehicle."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.vehicle_labels = set(param_storage()['vehicle_labels'])
+        self.roi_element_name = param_storage()['vehicle_roi']['element_name']
+        self.roi_label = param_storage()['vehicle_roi']['label']
+
+    def process_frame(self, buffer: Gst.Buffer, frame_meta: NvDsFrameMeta):
+        """Callback on each frame in a Deepstream pipeline batch."""
+
+        # the frame objects are collected before adding new ones
+        # to avoid modifying the metadata while iterating over it
+        vehicles = [
+            obj_meta
+            for obj_meta in frame_meta.objects
+            if obj_meta.label in self.vehicle_labels
+        ]
+
+        frame_width = frame_meta.video_frame.width
+        frame_height = frame_meta.video_frame.height
+
+        for vehicle in vehicles:
+            # the tracker may return bboxes that stick out of the frame
+            # (see enableBboxUnClipping in the tracker config), while a proxy
+            # is only valid as a model input if it fits in the viewport
+            left, top, right, bottom = vehicle.bbox.as_ltrb()
+            left, top = max(left, 0.0), max(top, 0.0)
+            right, bottom = min(right, frame_width), min(bottom, frame_height)
+            if right <= left or bottom <= top:
+                continue
+
+            roi_meta = ObjectMeta(
+                element_name=self.roi_element_name,
+                label=self.roi_label,
+                bbox=BBox.ltrb(left, top, right, bottom),
+                confidence=vehicle.confidence,
+            )
+            # the parent is assigned after the object is added to the frame:
+            # if it is set beforehand, add_obj_meta() passes it to the DeepStream
+            # object meta, whose parent setter reads the object uid, which
+            # assigns one, and the uid cannot be assigned twice (UIDError)
+            frame_meta.add_obj_meta(roi_meta)
+            roi_meta.parent = vehicle

--- a/samples/license_plate_recognition/module.yml
+++ b/samples/license_plate_recognition/module.yml
@@ -18,10 +18,27 @@ parameters:
     module: samples.license_plate_recognition.overlay
     class_name: Overlay
     rendered_objects:
+      # each vehicle type is rendered with its own color;
+      # the proxy "vehicle" object is not listed here, hence it is not rendered
       detector:
         car:
           bbox:
             border_color: '00FF00FF'  # Green
+            background_color: '00000000'  # transparent
+            thickness: 4
+        motorcycle:
+          bbox:
+            border_color: 'FFFF00FF'  # Yellow
+            background_color: '00000000'  # transparent
+            thickness: 4
+        bus:
+          bbox:
+            border_color: 'FF00FFFF'  # Magenta
+            background_color: '00000000'  # transparent
+            thickness: 4
+        truck:
+          bbox:
+            border_color: 'FF8000FF'  # Orange
             background_color: '00000000'  # transparent
             thickness: 4
       lpd:
@@ -34,9 +51,15 @@ parameters:
             font_scale: 1.5
             thickness: 2
 
-  detected_object:
-    label: car
-  
+  # COCO vehicle types predicted by the detector; each type keeps its own label,
+  # so that downstream units are able to distinguish between them
+  vehicle_labels: [car, motorcycle, bus, truck]
+
+  # proxy object created for every detected vehicle, see create_vehicle_roi.py
+  vehicle_roi:
+    element_name: create_vehicle_roi
+    label: vehicle
+
   default_yolo_converter:
     module: savant.converter.yolo
     class_name: TensorToBBoxConverter
@@ -76,19 +99,39 @@ pipeline:
           layer_names: [output0]
           num_detected_classes: 80  # required for YOLOv11
           converter: ${parameters.default_yolo_converter}
+          # every COCO vehicle type gets its own label, see parameters.vehicle_labels
           objects:
             - class_id: 2
-              label: ${parameters.detected_object.label}
+              label: car
               selector: ${parameters.default_yolo_selector}
             - class_id: 3
-              label: ${parameters.detected_object.label}
+              label: motorcycle
               selector: ${parameters.default_yolo_selector}
             - class_id: 5
-              label: ${parameters.detected_object.label}
+              label: bus
               selector: ${parameters.default_yolo_selector}
             - class_id: 7
-              label: ${parameters.detected_object.label}
+              label: truck
               selector: ${parameters.default_yolo_selector}
+
+    # tracker;
+    # it is placed before the proxy ROI unit so that the tracker only receives
+    # the vehicles themselves: a proxy occupies the same area as its parent and
+    # would be discarded (or discard the parent) by the new target policy
+    # of the tracker (see minIouDiff4NewTarget in the tracker config)
+    - element: nvtracker
+      properties:
+        ll-lib-file: /opt/nvidia/deepstream/deepstream/lib/libnvds_nvmultiobjecttracker.so
+        ll-config-file: ${oc.env:PROJECT_PATH}/samples/assets/tracker/config_tracker_NvDCF_perf.yml
+        tracker-width: 640
+        tracker-height: 384
+        display-tracking-id: 0
+
+    # add a proxy "vehicle" child object to each detected vehicle;
+    # it is used as the input object for the LPD model
+    - element: pyfunc
+      module: samples.license_plate_recognition.create_vehicle_roi
+      class_name: CreateVehicleROI
 
     # LPD https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/lpdnet
     - element: nvinfer@detector
@@ -102,7 +145,7 @@ pipeline:
         model_file: LPDNet_usa_pruned_tao5.onnx
         batch_size: 16
         input:
-          object: detector.${parameters.detected_object.label}
+          object: ${parameters.vehicle_roi.element_name}.${parameters.vehicle_roi.label}
           layer_name: input_1:0
           shape: [3, 480, 640]
           scale_factor: 0.0039215697906911373
@@ -118,15 +161,6 @@ pipeline:
                   nms_iou_threshold: 0.5
                   min_width: 24
                   min_height: 16
-
-    # tracker
-    - element: nvtracker
-      properties:
-        ll-lib-file: /opt/nvidia/deepstream/deepstream/lib/libnvds_nvmultiobjecttracker.so
-        ll-config-file: ${oc.env:PROJECT_PATH}/samples/assets/tracker/config_tracker_NvDCF_perf.yml
-        tracker-width: 640
-        tracker-height: 384
-        display-tracking-id: 0
 
     # # LPR https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/lprnet
     # - element: nvinfer@classifier


### PR DESCRIPTION
  Closes #1143

  The detector in the license plate demo used to assign a single `car` label to all COCO vehicle types it predicts,
  which merged the metadata and prevented downstream units from telling the types apart.

  ### Changes

  - Each COCO vehicle type predicted by the detector now keeps its own label: `car`, `motorcycle`, `bus`, `truck`. Every
  type is rendered with its own color.
  - A new PyFunc, `create_vehicle_roi.py`, adds a proxy child object labeled `vehicle` to each detected vehicle. It
  occupies the same area as its parent and serves as the input object for the LPD model, so that a single model unit
  covers every vehicle type. The proxy is not listed in `draw_func.rendered_objects`, hence it is not displayed.
  - The ROI is not adjusted per vehicle type, as requested in the issue.

  ### Notes on the pipeline order

  The tracker is placed right after the detector, before the proxy unit. A proxy fully overlaps its parent, so when the
  tracker receives both, one of them is discarded by its new target policy (`minIouDiff4NewTarget` in the tracker
  config) and the vehicle loses its bounding box. With this order the tracker only sees the vehicles themselves, and the
  LPD model still runs on the proxies.

  The proxy bounding box is trimmed to the frame: the tracker may return bboxes sticking out of it
  (`enableBboxUnClipping`), and an object out of the viewport is rejected by `add_obj_meta()`.

  ### Testing

  Ran the demo with `samples/license_plate_recognition/docker-compose.x86.yml` on x86 + DeepStream 7.1: every vehicle
  type gets its own colored bounding box, license plates are detected and recognized, and no proxy object is drawn.